### PR TITLE
feat(docs): sync accordion examples and documentation

### DIFF
--- a/src/pages/ui/accordion.mdx
+++ b/src/pages/ui/accordion.mdx
@@ -1,0 +1,140 @@
+---
+title: Accordion
+slug: accordion
+description: A vertically stacked set of interactive headings that each reveal a section of content.
+---
+
+# Accordion
+
+A vertically stacked set of interactive headings that each reveal a section of content.
+
+## Installation
+
+### CLI
+
+```package-dlx
+shadcn@latest add accordion
+```
+
+### Manual
+
+Copy and paste the following code into your project.
+
+```tsx file=../../registry/ui/accordion.tsx showLineNumbers
+
+```
+
+## Usage
+
+```tsx
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "~/components/ui/accordion";
+```
+
+```tsx showLineNumbers
+<Accordion>
+  <AccordionItem value="item-1">
+    <AccordionTrigger>Is it accessible?</AccordionTrigger>
+    <AccordionContent>
+      Yes. It adheres to the WAI-ARIA design pattern.
+    </AccordionContent>
+  </AccordionItem>
+</Accordion>
+```
+
+## Examples
+
+Here are the source code of all the examples from the preview page:
+
+### Basic
+
+```tsx
+import { For } from "solid-js";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/registry/ui/accordion";
+```
+
+```tsx file=../../registry/examples/accordion-example.tsx#L32-L67
+
+```
+
+### Multiple
+
+```tsx
+import { For } from "solid-js";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/registry/ui/accordion";
+```
+
+```tsx file=../../registry/examples/accordion-example.tsx#L69-L101
+
+```
+
+### With Borders
+
+```tsx
+import { For } from "solid-js";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/registry/ui/accordion";
+```
+
+```tsx file=../../registry/examples/accordion-example.tsx#L103-L157
+
+```
+
+### In Card
+
+```tsx
+import { ArrowUpRight } from "lucide-solid";
+import { For } from "solid-js";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/registry/ui/accordion";
+import { Button } from "@/registry/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/registry/ui/card";
+```
+
+```tsx file=../../registry/examples/accordion-example.tsx#L159-L288
+
+```
+
+### With Disabled
+
+```tsx
+import { For } from "solid-js";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/registry/ui/accordion";
+```
+
+```tsx file=../../registry/examples/accordion-example.tsx#L290-L337
+
+```

--- a/src/registry/examples/accordion-example.tsx
+++ b/src/registry/examples/accordion-example.tsx
@@ -1,0 +1,337 @@
+/** biome-ignore-all lint/a11y/useValidAnchor: <example file> */
+import { ArrowUpRight } from "lucide-solid";
+import { For } from "solid-js";
+import { Example, ExampleWrapper } from "@/components/example";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/registry/ui/accordion";
+import { Button } from "@/registry/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/registry/ui/card";
+
+export default function AccordionExample() {
+  return (
+    <ExampleWrapper class="w-full max-w-4xl lg:grid-cols-1 2xl:max-w-4xl 2xl:grid-cols-1">
+      <AccordionBasic />
+      <AccordionMultiple />
+      <AccordionWithBorders />
+      <AccordionInCard />
+      <AccordionWithDisabled />
+    </ExampleWrapper>
+  );
+}
+
+function AccordionBasic() {
+  const items = [
+    {
+      value: "item-1",
+      trigger: "Is it accessible?",
+      content: "Yes. It adheres to the WAI-ARIA design pattern.",
+    },
+    {
+      value: "item-2",
+      trigger: "Is it styled?",
+      content:
+        "Yes. It comes with default styles that matches the other components' aesthetic.",
+    },
+    {
+      value: "item-3",
+      trigger: "Is it animated?",
+      content:
+        "Yes. It's animated by default, but you can disable it if you prefer.",
+    },
+  ];
+
+  return (
+    <Example title="Basic">
+      <Accordion class="mx-auto max-w-lg">
+        <For each={items}>
+          {(item) => (
+            <AccordionItem value={item.value}>
+              <AccordionTrigger>{item.trigger}</AccordionTrigger>
+              <AccordionContent>{item.content}</AccordionContent>
+            </AccordionItem>
+          )}
+        </For>
+      </Accordion>
+    </Example>
+  );
+}
+
+function AccordionMultiple() {
+  const items = [
+    {
+      value: "item-1",
+      trigger:
+        "What are the key considerations when implementing a comprehensive enterprise-level authentication system?",
+      content:
+        "Implementing a robust enterprise authentication system requires careful consideration of multiple factors. This includes secure password hashing and storage, multi-factor authentication (MFA) implementation, session management, OAuth2 and SSO integration, regular security audits, rate limiting to prevent brute force attacks, and maintaining detailed audit logs. Additionally, you'll need to consider scalability, performance impact, and compliance with relevant data protection regulations such as GDPR or HIPAA.",
+    },
+    {
+      value: "item-2",
+      trigger:
+        "How does modern distributed system architecture handle eventual consistency and data synchronization across multiple regions?",
+      content:
+        "Modern distributed systems employ various strategies to maintain data consistency across regions. This often involves using techniques like CRDT (Conflict-Free Replicated Data Types), vector clocks, and gossip protocols. Systems might implement event sourcing patterns, utilize message queues for asynchronous updates, and employ sophisticated conflict resolution strategies. Popular solutions like Amazon's DynamoDB and Google's Spanner demonstrate different approaches to solving these challenges, balancing between consistency, availability, and partition tolerance as described in the CAP theorem.",
+    },
+  ];
+
+  return (
+    <Example title="Multiple">
+      <Accordion multiple class="mx-auto max-w-lg">
+        <For each={items}>
+          {(item) => (
+            <AccordionItem value={item.value}>
+              <AccordionTrigger>{item.trigger}</AccordionTrigger>
+              <AccordionContent>{item.content}</AccordionContent>
+            </AccordionItem>
+          )}
+        </For>
+      </Accordion>
+    </Example>
+  );
+}
+
+function AccordionWithBorders() {
+  const items = [
+    {
+      value: "billing",
+      trigger: "How does billing work?",
+      content:
+        "We offer monthly and annual subscription plans. Billing is charged at the beginning of each cycle, and you can cancel anytime. All plans include automatic backups, 24/7 support, and unlimited team members. There are no hidden fees or setup costs.",
+    },
+    {
+      value: "security",
+      trigger: "Is my data secure?",
+      content:
+        "Yes. We use end-to-end encryption, SOC 2 Type II compliance, and regular third-party security audits. All data is encrypted at rest and in transit using industry-standard protocols. We also offer optional two-factor authentication and single sign-on for enterprise customers.",
+    },
+    {
+      value: "integration",
+      trigger: "What integrations do you support?",
+      content: (
+        <>
+          <p>
+            We integrate with 500+ popular tools including Slack, Zapier,
+            Salesforce, HubSpot, and more. You can also build custom
+            integrations using our REST API and webhooks.{" "}
+          </p>
+          <p>
+            Our API documentation includes code examples in 10+ programming
+            languages.
+          </p>
+        </>
+      ),
+    },
+  ];
+
+  return (
+    <Example title="With Borders">
+      <Accordion class="style-lyra:gap-2 style-vega:gap-2 style-nova:gap-2 mx-auto max-w-lg">
+        <For each={items}>
+          {(item) => (
+            <AccordionItem
+              value={item.value}
+              class="style-vega:border style-nova:border style-lyra:border style-vega:rounded-lg style-nova:rounded-lg"
+            >
+              <AccordionTrigger class="style-nova:px-2.5 style-nova:text-sm style-vega:text-sm style-maia:text-sm style-mira:text-xs style-lyra:px-2 style-lyra:text-xs style-vega:px-4 font-medium">
+                {item.trigger}
+              </AccordionTrigger>
+              <AccordionContent class="text-muted-foreground style-nova:px-2.5 style-nova:text-sm style-lyra:px-2 style-lyra:text-xs style-vega:px-4 style-maia:px-0 style-mira:px-0">
+                {item.content}
+              </AccordionContent>
+            </AccordionItem>
+          )}
+        </For>
+      </Accordion>
+    </Example>
+  );
+}
+
+function AccordionInCard() {
+  const items = [
+    {
+      value: "plans",
+      trigger: "What subscription plans do you offer?",
+      content: (
+        <>
+          <p>
+            We offer three subscription tiers: Starter ($9/month), Professional
+            ($29/month), and Enterprise ($99/month). Each plan includes
+            increasing storage limits, API access, priority support, and team
+            collaboration features.
+          </p>
+          <p>
+            <a href="#">Annual billing is available</a> with a 20% discount. All
+            plans include a 14-day free trial with no credit card required.
+          </p>
+          <Button size="sm">
+            View plans
+            <ArrowUpRight />
+          </Button>
+        </>
+      ),
+    },
+    {
+      value: "billing",
+      trigger: "How does billing work?",
+      content: (
+        <>
+          <p>
+            Billing occurs automatically at the start of each billing cycle. We
+            accept all major credit cards, PayPal, and ACH transfers for
+            enterprise customers.
+          </p>
+          <p>
+            You&apos;ll receive an invoice via email after each payment. You can
+            update your payment method or billing information anytime in your
+            account settings. Failed payments will trigger automated retry
+            attempts and email notifications.
+          </p>
+        </>
+      ),
+    },
+    {
+      value: "upgrade",
+      trigger: "Can I upgrade or downgrade my plan?",
+      content: (
+        <>
+          <p>
+            Yes, you can change your plan at any time. When upgrading,
+            you&apos;ll be charged a prorated amount for the remainder of your
+            billing cycle and immediately gain access to new features.
+          </p>
+          <p>
+            When downgrading, the change takes effect at the end of your current
+            billing period, and you&apos;ll retain access to premium features
+            until then. No refunds are provided for downgrades.
+          </p>
+        </>
+      ),
+    },
+    {
+      value: "cancel",
+      trigger: "How do I cancel my subscription?",
+      content: (
+        <>
+          <p>
+            You can cancel your subscription anytime from your account settings.
+            There are no cancellation fees or penalties. Your access will
+            continue until the end of your current billing period.
+          </p>
+          <p>
+            After cancellation, your data is retained for 30 days in case you
+            want to reactivate. You can export all your data before or after
+            canceling. We&apos;d love to hear your feedback about why
+            you&apos;re leaving.
+          </p>
+        </>
+      ),
+    },
+    {
+      value: "refund",
+      trigger: "What is your refund policy?",
+      content: (
+        <>
+          <p>
+            We offer a 30-day money-back guarantee for new subscriptions. If
+            you&apos;re not satisfied within the first 30 days, contact our
+            support team for a full refund.
+          </p>
+          <p>
+            After 30 days, we don&apos;t provide refunds for partial billing
+            periods, but you can cancel anytime to avoid future charges.
+            Enterprise customers have custom refund terms outlined in their
+            contracts.
+          </p>
+        </>
+      ),
+    },
+  ];
+
+  return (
+    <Example title="In Card">
+      <Card class="mx-auto w-full max-w-lg gap-4">
+        <CardHeader>
+          <CardTitle>Subscription & Billing</CardTitle>
+          <CardDescription>
+            Common questions about your account, plans, and payments
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Accordion
+            multiple
+            defaultValue={["plans"]}
+            class="style-maia:rounded-md style-mira:rounded-md"
+          >
+            <For each={items}>
+              {(item) => (
+                <AccordionItem value={item.value}>
+                  <AccordionTrigger>{item.trigger}</AccordionTrigger>
+                  <AccordionContent>{item.content}</AccordionContent>
+                </AccordionItem>
+              )}
+            </For>
+          </Accordion>
+        </CardContent>
+      </Card>
+    </Example>
+  );
+}
+
+function AccordionWithDisabled() {
+  const items = [
+    {
+      value: "item-1",
+      trigger: "Can I access my account history?",
+      content:
+        "Yes, you can view your complete account history including all transactions, plan changes, and support tickets in the Account History section of your dashboard.",
+      disabled: false,
+    },
+    {
+      value: "item-2",
+      trigger: "Premium feature information",
+      content:
+        "This section contains information about premium features. Upgrade your plan to access this content.",
+      disabled: true,
+    },
+    {
+      value: "item-3",
+      trigger: "How do I update my email address?",
+      content:
+        "You can update your email address in your account settings. You'll receive a verification email at your new address to confirm the change.",
+      disabled: false,
+    },
+  ];
+
+  return (
+    <Example title="With Disabled">
+      <Accordion class="style-lyra:rounded-none style-vega:rounded-lg style-nova:rounded-lg style-maia:rounded-lg style-mira:rounded-lg mx-auto max-w-lg overflow-hidden border">
+        <For each={items}>
+          {(item) => (
+            <AccordionItem
+              value={item.value}
+              disabled={item.disabled}
+              class="data-open:bg-muted/50 p-1"
+            >
+              <AccordionTrigger class="style-nova:px-2.5 style-lyra:px-2 style-vega:px-4">
+                {item.trigger}
+              </AccordionTrigger>
+              <AccordionContent class="style-nova:px-2.5 style-lyra:px-2 style-vega:px-4">
+                {item.content}
+              </AccordionContent>
+            </AccordionItem>
+          )}
+        </For>
+      </Accordion>
+    </Example>
+  );
+}


### PR DESCRIPTION
## Summary

- Sync 5 accordion examples from Shadcn UI (Basic, Multiple, With Borders, In Card, With Disabled)
- Transform React patterns to SolidJS (className → class, map → For, etc.)
- Create MDX documentation with Usage and Examples sections

## Files Changed

- `src/registry/examples/accordion-example.tsx` - Component examples (5 variants)
- `src/pages/ui/accordion.mdx` - Documentation page

## Validation

- [x] Type checking passes (no accordion-related errors)
- [x] Playwright navigation successful
- [x] Playwright snapshot captured
- [x] Playwright screenshot taken - all examples render correctly

## Example Variants

| Example | Description |
|---------|-------------|
| Basic | Simple accordion with 3 collapsible items |
| Multiple | Allows multiple items to be expanded simultaneously |
| With Borders | Styled accordion items with visible borders |
| In Card | Accordion wrapped in a Card component with default expanded item |
| With Disabled | Demonstrates disabled accordion items |

🤖 Generated with [Claude Code](https://claude.com/claude-code)