### PR TITLE
feat(docs): add Examples section to alert documentation

### DIFF
--- a/src/pages/ui/alert.mdx
+++ b/src/pages/ui/alert.mdx
@@ -31,11 +31,77 @@ import { Alert, AlertDescription, AlertTitle } from "~/components/ui/alert";
 ```
 
 ```tsx showLineNumbers
-<Alert>
-  <AlertCircle class="size-4" />
+<Alert variant="default | destructive">
+  <Terminal />
   <AlertTitle>Heads up!</AlertTitle>
   <AlertDescription>
-    You can add components to your app using the cli.
+    You can add components and dependencies to your app using the cli.
   </AlertDescription>
 </Alert>
+```
+
+## Examples
+
+Here are the source code of all the examples from the preview page:
+
+### Basic
+
+```tsx
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+} from "~/components/ui/alert";
+```
+
+```tsx file=../../registry/examples/alert-example.tsx#L19-L36
+
+```
+
+### With Icons
+
+```tsx
+import { CircleAlert } from "lucide-solid";
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+} from "~/components/ui/alert";
+```
+
+```tsx file=../../registry/examples/alert-example.tsx#L38-L93
+
+```
+
+### Destructive
+
+```tsx
+import { CircleAlert } from "lucide-solid";
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+} from "~/components/ui/alert";
+```
+
+```tsx file=../../registry/examples/alert-example.tsx#L95-L121
+
+```
+
+### With Actions
+
+```tsx
+import { CircleAlert } from "lucide-solid";
+import {
+  Alert,
+  AlertAction,
+  AlertDescription,
+  AlertTitle,
+} from "~/components/ui/alert";
+import { Badge } from "~/components/ui/badge";
+import { Button } from "~/components/ui/button";
+```
+
+```tsx file=../../registry/examples/alert-example.tsx#L123-L148
+
 ```


### PR DESCRIPTION
## Summary

- Add Examples section to alert component MDX documentation
- Document all 4 example variants with proper imports and source code references:
  - **Basic**: Simple alerts with title and/or description
  - **With Icons**: Alerts with CircleAlert icon variants
  - **Destructive**: Error/warning variant alerts
  - **With Actions**: Alerts with Button and Badge actions

## Screenshot

![Alert Examples Validation](https://raw.githubusercontent.com/carere/zaidan/feat/sync-alert-examples/alert-examples-validation.png)

## Validation

| Check | Status |
|-------|--------|
| Type checking | ✅ PASS (no alert-related errors) |
| Playwright navigation | ✅ PASS |
| Playwright snapshot | ✅ PASS |
| Playwright screenshot | ✅ PASS |

## Files Changed

- `src/pages/ui/alert.mdx` - Added Examples section with 4 documented variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)