### PR TITLE
feat(docs): sync alert-dialog examples and documentation

### DIFF
--- a/src/pages/ui/alert-dialog.mdx
+++ b/src/pages/ui/alert-dialog.mdx
@@ -1,0 +1,205 @@
+---
+title: Alert Dialog
+slug: alert-dialog
+description: A modal dialog that interrupts the user with important content and expects a response.
+---
+
+# Alert Dialog
+
+A modal dialog that interrupts the user with important content and expects a response.
+
+## Installation
+
+### CLI
+
+```package-dlx
+shadcn@latest add alert-dialog
+```
+
+### Manual
+
+Copy and paste the following code into your project.
+
+```tsx file=../../registry/ui/alert-dialog.tsx showLineNumbers
+
+```
+
+## Usage
+
+```tsx
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "~/components/ui/alert-dialog";
+```
+
+```tsx showLineNumbers
+<AlertDialog>
+  <AlertDialogTrigger>Open</AlertDialogTrigger>
+  <AlertDialogContent>
+    <AlertDialogHeader>
+      <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
+      <AlertDialogDescription>
+        This action cannot be undone. This will permanently delete your account
+        and remove your data from our servers.
+      </AlertDialogDescription>
+    </AlertDialogHeader>
+    <AlertDialogFooter>
+      <AlertDialogCancel>Cancel</AlertDialogCancel>
+      <AlertDialogAction>Continue</AlertDialogAction>
+    </AlertDialogFooter>
+  </AlertDialogContent>
+</AlertDialog>
+```
+
+## Examples
+
+Here are the source code of all the examples from the preview page:
+
+### Basic
+
+```tsx
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "~/components/ui/alert-dialog";
+import { Button } from "~/components/ui/button";
+```
+
+```tsx file=../../registry/examples/alert-dialog-example.tsx#L40-L63
+
+```
+
+### Small
+
+```tsx
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "~/components/ui/alert-dialog";
+import { Button } from "~/components/ui/button";
+```
+
+```tsx file=../../registry/examples/alert-dialog-example.tsx#L65-L87
+
+```
+
+### With Media
+
+```tsx
+import { Bluetooth } from "lucide-solid";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "~/components/ui/alert-dialog";
+import { Button } from "~/components/ui/button";
+```
+
+```tsx file=../../registry/examples/alert-dialog-example.tsx#L89-L114
+
+```
+
+### Small With Media
+
+```tsx
+import { Bluetooth } from "lucide-solid";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "~/components/ui/alert-dialog";
+import { Button } from "~/components/ui/button";
+```
+
+```tsx file=../../registry/examples/alert-dialog-example.tsx#L116-L142
+
+```
+
+### Destructive
+
+```tsx
+import { Trash2 } from "lucide-solid";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "~/components/ui/alert-dialog";
+import { Button } from "~/components/ui/button";
+```
+
+```tsx file=../../registry/examples/alert-dialog-example.tsx#L144-L170
+
+```
+
+### In Dialog
+
+```tsx
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "~/components/ui/alert-dialog";
+import { Button } from "~/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "~/components/ui/dialog";
+```
+
+```tsx file=../../registry/examples/alert-dialog-example.tsx#L172-L206
+
+```

--- a/src/registry/examples/alert-dialog-example.tsx
+++ b/src/registry/examples/alert-dialog-example.tsx
@@ -1,0 +1,206 @@
+/** biome-ignore-all lint/a11y/useValidAnchor: <example file> */
+import { Bluetooth, Trash2 } from "lucide-solid";
+import { Example, ExampleWrapper } from "@/components/example";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/registry/ui/alert-dialog";
+import { Button } from "@/registry/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/registry/ui/dialog";
+
+export default function AlertDialogExample() {
+  return (
+    <ExampleWrapper>
+      <AlertDialogBasic />
+      <AlertDialogSmall />
+      <AlertDialogWithMedia />
+      <AlertDialogSmallWithMedia />
+      <AlertDialogDestructive />
+      <AlertDialogInDialog />
+    </ExampleWrapper>
+  );
+}
+
+function AlertDialogBasic() {
+  return (
+    <Example title="Basic" class="items-center">
+      <AlertDialog>
+        <AlertDialogTrigger as={Button} variant="outline">
+          Default
+        </AlertDialogTrigger>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This action cannot be undone. This will permanently delete your account and remove
+              your data from our servers.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction>Continue</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </Example>
+  );
+}
+
+function AlertDialogSmall() {
+  return (
+    <Example title="Small" class="items-center">
+      <AlertDialog>
+        <AlertDialogTrigger as={Button} variant="outline">
+          Small
+        </AlertDialogTrigger>
+        <AlertDialogContent size="sm">
+          <AlertDialogHeader>
+            <AlertDialogTitle>Allow accessory to connect?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Do you want to allow the USB accessory to connect to this device?
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Don't allow</AlertDialogCancel>
+            <AlertDialogAction>Allow</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </Example>
+  );
+}
+
+function AlertDialogWithMedia() {
+  return (
+    <Example title="With Media" class="items-center">
+      <AlertDialog>
+        <AlertDialogTrigger as={Button} variant="outline">
+          Default (Media)
+        </AlertDialogTrigger>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogMedia>
+              <Bluetooth />
+            </AlertDialogMedia>
+            <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will permanently delete your account and remove your data from our servers.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction>Continue</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </Example>
+  );
+}
+
+function AlertDialogSmallWithMedia() {
+  return (
+    <Example title="Small With Media" class="items-center">
+      <AlertDialog>
+        <AlertDialogTrigger as={Button} variant="outline">
+          Small (Media)
+        </AlertDialogTrigger>
+
+        <AlertDialogContent size="sm">
+          <AlertDialogHeader>
+            <AlertDialogMedia>
+              <Bluetooth />
+            </AlertDialogMedia>
+            <AlertDialogTitle>Allow accessory to connect?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Do you want to allow the USB accessory to connect to this device?
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Don't allow</AlertDialogCancel>
+            <AlertDialogAction>Allow</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </Example>
+  );
+}
+
+function AlertDialogDestructive() {
+  return (
+    <Example title="Destructive" class="items-center">
+      <AlertDialog>
+        <AlertDialogTrigger as={Button} variant="destructive">
+          Delete Chat
+        </AlertDialogTrigger>
+        <AlertDialogContent size="sm">
+          <AlertDialogHeader>
+            <AlertDialogMedia class="bg-destructive/10 text-destructive dark:bg-destructive/20 dark:text-destructive">
+              <Trash2 />
+            </AlertDialogMedia>
+            <AlertDialogTitle>Delete chat?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will permanently delete this chat conversation. View <a href="#">Settings</a>{" "}
+              delete any memories saved during this chat.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel variant="ghost">Cancel</AlertDialogCancel>
+            <AlertDialogAction variant="destructive">Delete</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </Example>
+  );
+}
+
+function AlertDialogInDialog() {
+  return (
+    <Example title="In Dialog" class="items-center">
+      <Dialog>
+        <DialogTrigger as={Button} variant="outline">
+          Open Dialog
+        </DialogTrigger>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Alert Dialog Example</DialogTitle>
+            <DialogDescription>Click the button below to open an alert dialog.</DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <AlertDialog>
+              <AlertDialogTrigger as={Button}>Open Alert Dialog</AlertDialogTrigger>
+              <AlertDialogContent size="sm">
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    This action cannot be undone. This will permanently delete your account and
+                    remove your data from our servers.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction>Continue</AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </Example>
+  );
+}


### PR DESCRIPTION
## Summary

- Sync examples from Shadcn UI for alert-dialog component
- Transform React patterns to SolidJS
- Create MDX documentation with Examples section

## Example Variants

- **Basic** - Standard alert dialog with title, description, and action buttons
- **Small** - Compact variant with smaller content area
- **With Media** - Includes an icon (Bluetooth) in the media slot
- **Small With Media** - Compact variant with icon
- **Destructive** - Red-themed dialog for destructive actions (delete confirmation)
- **In Dialog** - Alert dialog nested inside a regular dialog

## Files Changed

- `src/registry/examples/alert-dialog-example.tsx` - Component examples (207 lines)
- `src/pages/ui/alert-dialog.mdx` - Documentation (204 lines)

## Validation

- [x] Build passes
- [x] Playwright visual validation completed
- [x] Alert dialogs open and close correctly
- [x] No console errors

## QA Video

[video.webm](https://github.com/user-attachments/assets/febd023c-3c47-40a2-b95c-19d21ca7dd53)

🤖 Generated with [Claude Code](https://claude.com/claude-code)