### PR TITLE
feat(docs): sync checkbox examples and documentation

### DIFF
--- a/src/pages/ui/checkbox.mdx
+++ b/src/pages/ui/checkbox.mdx
@@ -18,6 +18,12 @@ shadcn@latest add checkbox
 
 ### Manual
 
+Install the following dependencies:
+
+```package-install
+@kobalte/core
+```
+
 Copy and paste the following code into your project.
 
 ```tsx file=../../registry/ui/checkbox.tsx showLineNumbers
@@ -34,4 +40,100 @@ import { Checkbox, CheckboxLabel } from "~/components/ui/checkbox";
 <Checkbox>
   <CheckboxLabel>Accept terms and conditions</CheckboxLabel>
 </Checkbox>
+```
+
+## Examples
+
+Here are the source code of all the examples from the preview page:
+
+### Basic
+
+```tsx
+import { Checkbox } from "~/components/ui/checkbox";
+import { Field, FieldLabel } from "~/components/ui/field";
+```
+
+```tsx file=../../registry/examples/checkbox-example.tsx#L29-L38
+
+```
+
+### With Description
+
+```tsx
+import { Checkbox } from "~/components/ui/checkbox";
+import { Field, FieldContent, FieldDescription, FieldLabel } from "~/components/ui/field";
+```
+
+```tsx file=../../registry/examples/checkbox-example.tsx#L40-L54
+
+```
+
+### Invalid
+
+```tsx
+import { Checkbox } from "~/components/ui/checkbox";
+import { Field, FieldLabel } from "~/components/ui/field";
+```
+
+```tsx file=../../registry/examples/checkbox-example.tsx#L56-L65
+
+```
+
+### Disabled
+
+```tsx
+import { Checkbox } from "~/components/ui/checkbox";
+import { Field, FieldLabel } from "~/components/ui/field";
+```
+
+```tsx file=../../registry/examples/checkbox-example.tsx#L67-L76
+
+```
+
+### With Title
+
+```tsx
+import { Checkbox } from "~/components/ui/checkbox";
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldGroup,
+  FieldLabel,
+  FieldTitle,
+} from "~/components/ui/field";
+```
+
+```tsx file=../../registry/examples/checkbox-example.tsx#L78-L107
+
+```
+
+### In Table
+
+```tsx
+import { createSignal, For } from "solid-js";
+import { Checkbox } from "~/components/ui/checkbox";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "~/components/ui/table";
+```
+
+```tsx file=../../registry/examples/checkbox-example.tsx#L109-L193
+
+```
+
+### Group
+
+```tsx
+import { Checkbox } from "~/components/ui/checkbox";
+import { Field, FieldLabel } from "~/components/ui/field";
+```
+
+```tsx file=../../registry/examples/checkbox-example.tsx#L195-L227
+
 ```

--- a/src/registry/examples/checkbox-example.tsx
+++ b/src/registry/examples/checkbox-example.tsx
@@ -1,3 +1,5 @@
+import { createSignal, For } from "solid-js";
+
 import { Example, ExampleWrapper } from "@/components/example";
 import { Checkbox } from "@/registry/ui/checkbox";
 import {
@@ -7,7 +9,8 @@ import {
   FieldGroup,
   FieldLabel,
   FieldTitle,
-} from "../ui/field";
+} from "@/registry/ui/field";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/registry/ui/table";
 
 export default function CheckboxExample() {
   return (
@@ -17,7 +20,7 @@ export default function CheckboxExample() {
       <CheckboxInvalid />
       <CheckboxDisabled />
       <CheckboxWithTitle />
-      {/* <CheckboxInTable /> */}
+      <CheckboxInTable />
       <CheckboxGroup />
     </ExampleWrapper>
   );
@@ -103,89 +106,91 @@ function CheckboxWithTitle() {
   );
 }
 
-// const tableData = [
-//   {
-//     id: "1",
-//     name: "Sarah Chen",
-//     email: "sarah.chen@example.com",
-//     role: "Admin",
-//   },
-//   {
-//     id: "2",
-//     name: "Marcus Rodriguez",
-//     email: "marcus.rodriguez@example.com",
-//     role: "User",
-//   },
-//   {
-//     id: "3",
-//     name: "Priya Patel",
-//     email: "priya.patel@example.com",
-//     role: "User",
-//   },
-//   {
-//     id: "4",
-//     name: "David Kim",
-//     email: "david.kim@example.com",
-//     role: "Editor",
-//   },
-// ];
+const tableData = [
+  {
+    id: "1",
+    name: "Sarah Chen",
+    email: "sarah.chen@example.com",
+    role: "Admin",
+  },
+  {
+    id: "2",
+    name: "Marcus Rodriguez",
+    email: "marcus.rodriguez@example.com",
+    role: "User",
+  },
+  {
+    id: "3",
+    name: "Priya Patel",
+    email: "priya.patel@example.com",
+    role: "User",
+  },
+  {
+    id: "4",
+    name: "David Kim",
+    email: "david.kim@example.com",
+    role: "Editor",
+  },
+];
 
-// function CheckboxInTable() {
-//   const [selectedRows, setSelectedRows] = createSignal(new Set(["1"]));
+function CheckboxInTable() {
+  const [selectedRows, setSelectedRows] = createSignal<Set<string>>(new Set(["1"]));
 
-//   const selectAll = selectedRows().size === tableData.length;
+  const selectAll = () => selectedRows().size === tableData.length;
 
-//   const handleSelectAll = (checked: boolean) => {
-//     if (checked) {
-//       setSelectedRows(new Set(tableData.map((row) => row.id)));
-//     } else {
-//       setSelectedRows(new Set<string>());
-//     }
-//   };
+  const handleSelectAll = (checked: boolean) => {
+    if (checked) {
+      setSelectedRows(new Set(tableData.map((row) => row.id)));
+    } else {
+      setSelectedRows(new Set<string>());
+    }
+  };
 
-//   const handleSelectRow = (id: string, checked: boolean) => {
-//     const newSelected = new Set(selectedRows);
-//     if (checked) {
-//       newSelected.add(id);
-//     } else {
-//       newSelected.delete(id);
-//     }
-//     setSelectedRows(newSelected);
-//   };
+  const handleSelectRow = (id: string, checked: boolean) => {
+    const newSelected = new Set(selectedRows());
+    if (checked) {
+      newSelected.add(id);
+    } else {
+      newSelected.delete(id);
+    }
+    setSelectedRows(newSelected);
+  };
 
-//   return (
-//     <Example title="In Table">
-//       <Table>
-//         <TableHeader>
-//           <TableRow>
-//             <TableHead className="w-8">
-//               <Checkbox id="select-all" checked={selectAll} onCheckedChange={handleSelectAll} />
-//             </TableHead>
-//             <TableHead>Name</TableHead>
-//             <TableHead>Email</TableHead>
-//             <TableHead>Role</TableHead>
-//           </TableRow>
-//         </TableHeader>
-//         <TableBody>
-//           {tableData.map((row) => (
-//             <TableRow key={row.id} data-state={selectedRows.has(row.id) ? "selected" : undefined}>
-//               <TableCell>
-//                 <Checkbox
-//                   id={`row-${row.id}`}
-//                   checked={selectedRows.has(row.id)}
-//                   onCheckedChange={(checked) => handleSelectRow(row.id, checked === true)}
-//                 />
-//               </TableCell>
-//               <TableCell className="font-medium">{row.name}</TableCell>
-//               <TableCell>{row.email}</TableCell>
-//               <TableCell>{row.role}</TableCell>
-//             </TableRow>
-//           ))}
-//         </TableBody>
-//       </Table>
-//     </Example>
-//   );
-// }
+  return (
+    <Example title="In Table">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead class="w-8">
+              <Checkbox id="select-all" checked={selectAll()} onChange={handleSelectAll} />
+            </TableHead>
+            <TableHead>Name</TableHead>
+            <TableHead>Email</TableHead>
+            <TableHead>Role</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          <For each={tableData}>
+            {(row) => (
+              <TableRow data-state={selectedRows().has(row.id) ? "selected" : undefined}>
+                <TableCell>
+                  <Checkbox
+                    id={`row-${row.id}`}
+                    checked={selectedRows().has(row.id)}
+                    onChange={(checked) => handleSelectRow(row.id, checked)}
+                  />
+                </TableCell>
+                <TableCell class="font-medium">{row.name}</TableCell>
+                <TableCell>{row.email}</TableCell>
+                <TableCell>{row.role}</TableCell>
+              </TableRow>
+            )}
+          </For>
+        </TableBody>
+      </Table>
+    </Example>
+  );
+}
 
 function CheckboxGroup() {
   return (

--- a/tests/checkbox.spec.ts
+++ b/tests/checkbox.spec.ts
@@ -1,0 +1,235 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Checkbox Component", () => {
+  test("examples", async ({ page }) => {
+    await page.goto("http://localhost:5175/ui/checkbox");
+
+    await page.waitForLoadState("networkidle");
+
+    // ------------------------------------------------------------
+    // Basic Example
+    // ------------------------------------------------------------
+
+    // 1. Get the basic section
+    const basicSection = page.getByText("Basic", { exact: true }).locator("..");
+
+    // 2. Verify the checkbox is visible and unchecked
+    const basicCheckbox = basicSection.getByRole("checkbox", {
+      name: "Accept terms and conditions",
+    });
+    await expect(basicCheckbox).toBeVisible();
+    await expect(basicCheckbox).not.toBeChecked();
+
+    // 3. Click the label to check the checkbox (Kobalte checkbox control intercepts pointer events)
+    await basicSection.getByText("Accept terms and conditions").click();
+
+    // 4. Verify the checkbox is now checked
+    await expect(basicCheckbox).toBeChecked();
+
+    // 5. Click the label again to uncheck it
+    await basicSection.getByText("Accept terms and conditions").click();
+
+    // 6. Verify the checkbox is now unchecked
+    await expect(basicCheckbox).not.toBeChecked();
+
+    // ------------------------------------------------------------
+    // With Description Example
+    // ------------------------------------------------------------
+
+    // 7. Get the with description section
+    const withDescSection = page.getByText("With Description", { exact: true }).locator("..");
+
+    // 8. Verify the checkbox is visible and checked by default
+    const descCheckbox = withDescSection.getByRole("checkbox", {
+      name: "Accept terms and conditions",
+    });
+    await expect(descCheckbox).toBeVisible();
+    await expect(descCheckbox).toBeChecked();
+
+    // 9. Verify the description text is visible
+    await expect(
+      withDescSection.getByText(
+        "By clicking this checkbox, you agree to the terms and conditions.",
+      ),
+    ).toBeVisible();
+
+    // 10. Toggle the checkbox by clicking the label
+    await withDescSection.getByText("Accept terms and conditions", { exact: true }).click();
+    await expect(descCheckbox).not.toBeChecked();
+
+    // ------------------------------------------------------------
+    // Invalid Example
+    // ------------------------------------------------------------
+
+    // 11. Get the invalid section
+    const invalidSection = page.getByText("Invalid", { exact: true }).locator("..");
+
+    // 12. Verify the checkbox is visible
+    const invalidCheckbox = invalidSection.getByRole("checkbox", {
+      name: "Accept terms and conditions",
+    });
+    await expect(invalidCheckbox).toBeVisible();
+
+    // 13. Toggle the invalid checkbox by clicking the label
+    await invalidSection.getByText("Accept terms and conditions").click();
+    await expect(invalidCheckbox).toBeChecked();
+
+    // ------------------------------------------------------------
+    // Disabled Example
+    // ------------------------------------------------------------
+
+    // 14. Get the disabled section
+    const disabledSection = page.getByText("Disabled", { exact: true }).locator("..");
+
+    // 15. Verify the checkbox is visible and disabled
+    const disabledCheckbox = disabledSection.getByRole("checkbox", {
+      name: "Enable notifications",
+    });
+    await expect(disabledCheckbox).toBeVisible();
+    await expect(disabledCheckbox).toBeDisabled();
+
+    // ------------------------------------------------------------
+    // With Title Example
+    // ------------------------------------------------------------
+
+    // 16. Get the with title section
+    const withTitleSection = page.getByText("With Title", { exact: true }).locator("..");
+
+    // 17. Verify the first checkbox (enabled) is visible and checked by default
+    const titleCheckbox1 = withTitleSection
+      .getByRole("checkbox", { name: /Enable notifications/ })
+      .first();
+    await expect(titleCheckbox1).toBeVisible();
+    await expect(titleCheckbox1).toBeChecked();
+
+    // 18. Verify the second checkbox (disabled) is visible and disabled
+    const titleCheckbox2 = withTitleSection
+      .getByRole("checkbox", { name: /Enable notifications/ })
+      .nth(1);
+    await expect(titleCheckbox2).toBeVisible();
+    await expect(titleCheckbox2).toBeDisabled();
+
+    // 19. Toggle the first checkbox by clicking its title
+    await withTitleSection.getByText("Enable notifications", { exact: true }).first().click();
+    await expect(titleCheckbox1).not.toBeChecked();
+
+    // ------------------------------------------------------------
+    // In Table Example
+    // ------------------------------------------------------------
+
+    // 20. Get the in table section
+    const tableSection = page.getByText("In Table", { exact: true }).locator("..");
+
+    // 21. Verify the table is visible
+    const table = tableSection.getByRole("table");
+    await expect(table).toBeVisible();
+
+    // 22. Verify Sarah Chen's row is selected by default
+    const sarahRow = table.getByRole("row", { name: /Sarah Chen/ });
+    await expect(sarahRow).toBeVisible();
+    const sarahCheckbox = sarahRow.getByRole("checkbox");
+    await expect(sarahCheckbox).toBeChecked();
+
+    // 23. Verify Marcus Rodriguez's row is not selected
+    const marcusRow = table.getByRole("row", { name: /Marcus Rodriguez/ });
+    const marcusCheckbox = marcusRow.getByRole("checkbox");
+    await expect(marcusCheckbox).not.toBeChecked();
+
+    // 24. Click Marcus's checkbox to select him (use force: true for table checkboxes)
+    await marcusCheckbox.click({ force: true });
+    await expect(marcusCheckbox).toBeChecked();
+
+    // 25. Click the "select all" checkbox in the header
+    const selectAllCheckbox = table.getByRole("columnheader").first().getByRole("checkbox");
+    await selectAllCheckbox.click({ force: true });
+
+    // 26. Verify all rows are now selected
+    await expect(sarahCheckbox).toBeChecked();
+    await expect(marcusCheckbox).toBeChecked();
+    const priyaCheckbox = table.getByRole("row", { name: /Priya Patel/ }).getByRole("checkbox");
+    await expect(priyaCheckbox).toBeChecked();
+    const davidCheckbox = table.getByRole("row", { name: /David Kim/ }).getByRole("checkbox");
+    await expect(davidCheckbox).toBeChecked();
+
+    // 27. Click select all again to deselect all
+    await selectAllCheckbox.click({ force: true });
+
+    // 28. Verify all rows are now deselected
+    await expect(sarahCheckbox).not.toBeChecked();
+    await expect(marcusCheckbox).not.toBeChecked();
+    await expect(priyaCheckbox).not.toBeChecked();
+    await expect(davidCheckbox).not.toBeChecked();
+
+    // ------------------------------------------------------------
+    // Group Example
+    // ------------------------------------------------------------
+
+    // 29. Get the group section
+    const groupSection = page.getByText("Group", { exact: true }).locator("..");
+
+    // 30. Verify the group label is visible
+    await expect(groupSection.getByText("Show these items on the desktop:")).toBeVisible();
+
+    // 31. Verify all checkboxes are visible and unchecked by default
+    const hardDisksCheckbox = groupSection.getByRole("checkbox", { name: "Hard disks" });
+    const externalDisksCheckbox = groupSection.getByRole("checkbox", { name: "External disks" });
+    const cdsCheckbox = groupSection.getByRole("checkbox", { name: "CDs, DVDs, and iPods" });
+    const serversCheckbox = groupSection.getByRole("checkbox", { name: "Connected servers" });
+
+    await expect(hardDisksCheckbox).toBeVisible();
+    await expect(hardDisksCheckbox).not.toBeChecked();
+    await expect(externalDisksCheckbox).toBeVisible();
+    await expect(externalDisksCheckbox).not.toBeChecked();
+    await expect(cdsCheckbox).toBeVisible();
+    await expect(cdsCheckbox).not.toBeChecked();
+    await expect(serversCheckbox).toBeVisible();
+    await expect(serversCheckbox).not.toBeChecked();
+
+    // 32. Check a few checkboxes by clicking their labels
+    await groupSection.getByText("Hard disks").click();
+    await groupSection.getByText("CDs, DVDs, and iPods").click();
+
+    // 33. Verify the selected checkboxes are checked
+    await expect(hardDisksCheckbox).toBeChecked();
+    await expect(cdsCheckbox).toBeChecked();
+    await expect(externalDisksCheckbox).not.toBeChecked();
+    await expect(serversCheckbox).not.toBeChecked();
+
+    // ------------------------------------------------------------
+    // Docs Page Test - Toggle to Docs and Scroll
+    // ------------------------------------------------------------
+
+    // 34. Click the toggle button to switch to docs view
+    await page.getByRole("button", { name: "Toggle between preview and docs" }).click();
+
+    // 35. Wait for docs view to load
+    await page.waitForTimeout(500);
+
+    // 36. Verify the docs page is visible by checking for the main heading
+    await expect(page.getByRole("heading", { name: "Checkbox", level: 1 })).toBeVisible();
+
+    // 37. Verify the Installation section is present
+    await expect(page.getByRole("heading", { name: "Installation", level: 2 })).toBeVisible();
+
+    // 38. Verify the Usage section is present
+    await expect(page.getByRole("heading", { name: "Usage", level: 2 })).toBeVisible();
+
+    // 39. Verify the Examples section is present
+    await expect(page.getByRole("heading", { name: "Examples", level: 2 })).toBeVisible();
+
+    // 40. Verify all example subsections are present
+    await expect(page.getByRole("heading", { name: "Basic", level: 3 })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "With Description", level: 3 })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Invalid", level: 3 })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Disabled", level: 3 })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "With Title", level: 3 })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "In Table", level: 3 })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Group", level: 3 })).toBeVisible();
+
+    // 41. Scroll to the bottom of the page to see all examples
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+
+    // 42. Wait for scroll animation
+    await page.waitForTimeout(300);
+  });
+});


### PR DESCRIPTION
## Summary

- Sync examples from Shadcn UI for checkbox component
- Transform React patterns to SolidJS (className → class, useState → createSignal, map → For)
- Update/create MDX documentation with Examples section
- Add Playwright test suite for checkbox component

## Example Variants Synced

1. **Basic** - Simple checkbox with label
2. **With Description** - Checkbox with description text
3. **Invalid** - Checkbox with invalid state
4. **Disabled** - Disabled checkbox
5. **With Title** - Checkbox with title and description in a group
6. **In Table** - Checkboxes in a data table with select all functionality
7. **Group** - Multiple checkboxes in a group

## Validation

- [x] Type checking passes
- [x] Playwright visual validation completed
- [x] Playwright test suite passes (all 7 examples + docs view)

## Video

[QA Video](https://okesuto.carere.dev/checkbox-qa-video.webm)

## Files Changed

- `src/registry/examples/checkbox-example.tsx` - Component examples (updated to include all 7 examples)
- `src/pages/ui/checkbox.mdx` - Documentation (added Examples section)
- `tests/checkbox.spec.ts` - Playwright test suite (new file)

🤖 Generated with [Claude Code](https://claude.com/code)