### PR TITLE
feat(docs): sync input-otp examples and documentation

### DIFF
--- a/src/pages/ui/input-otp.mdx
+++ b/src/pages/ui/input-otp.mdx
@@ -18,6 +18,12 @@ shadcn@latest add input-otp
 
 ### Manual
 
+Install the following dependencies:
+
+```package-install
+@corvu/otp-field
+```
+
 Copy and paste the following code into your project.
 
 ```tsx file=../../registry/ui/input-otp.tsx showLineNumbers
@@ -51,91 +57,144 @@ import {
 </InputOTP>
 ```
 
-## Pattern
+## Examples
 
-Use the `pattern` prop to define a custom pattern for the OTP input.
+Here are the source code of all the examples from the preview page:
+
+### Form
 
 ```tsx
-import { REGEXP_ONLY_DIGITS_AND_CHARS } from "@corvu/otp-field";
+import { RefreshCcw } from "lucide-solid";
+import { Example } from "~/components/example";
+import { Button } from "~/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "~/components/ui/card";
+import { Field, FieldDescription, FieldLabel } from "~/components/ui/field";
 import {
   InputOTP,
   InputOTPGroup,
+  InputOTPSeparator,
   InputOTPSlot,
 } from "~/components/ui/input-otp";
 ```
 
-```tsx showLineNumbers
-<InputOTP maxLength={6} pattern={REGEXP_ONLY_DIGITS_AND_CHARS}>
-  <InputOTPGroup>
-    <InputOTPSlot index={0} />
-    <InputOTPSlot index={1} />
-    <InputOTPSlot index={2} />
-    <InputOTPSlot index={3} />
-    <InputOTPSlot index={4} />
-    <InputOTPSlot index={5} />
-  </InputOTPGroup>
-</InputOTP>
+```tsx file=../../registry/examples/input-otp-example.tsx#L200-L254
+
 ```
 
-## Separator
+### Simple
 
-You can use the `<InputOTPSeparator />` component to add a separator between the input groups.
-
-```tsx showLineNumbers
-<InputOTP maxLength={6}>
-  <InputOTPGroup>
-    <InputOTPSlot index={0} />
-    <InputOTPSlot index={1} />
-  </InputOTPGroup>
-  <InputOTPSeparator />
-  <InputOTPGroup>
-    <InputOTPSlot index={2} />
-    <InputOTPSlot index={3} />
-  </InputOTPGroup>
-  <InputOTPSeparator />
-  <InputOTPGroup>
-    <InputOTPSlot index={4} />
-    <InputOTPSlot index={5} />
-  </InputOTPGroup>
-</InputOTP>
+```tsx
+import { Example } from "~/components/example";
+import { Field, FieldLabel } from "~/components/ui/field";
+import {
+  InputOTP,
+  InputOTPGroup,
+  InputOTPSeparator,
+  InputOTPSlot,
+} from "~/components/ui/input-otp";
 ```
 
-## Controlled
+```tsx file=../../registry/examples/input-otp-example.tsx#L33-L54
 
-You can use the `value` and `onValueChange` props to control the input value.
+```
 
-```tsx showLineNumbers
+### Digits Only
+
+```tsx
+import { Example } from "~/components/example";
+import { Field, FieldLabel } from "~/components/ui/field";
+import { InputOTP, InputOTPGroup, InputOTPSlot } from "~/components/ui/input-otp";
+```
+
+```tsx file=../../registry/examples/input-otp-example.tsx#L56-L74
+
+```
+
+### With Separator
+
+```tsx
 import { createSignal } from "solid-js";
-
-const [value, setValue] = createSignal("");
-
-// ...
-
-<InputOTP maxLength={6} value={value()} onValueChange={setValue}>
-  <InputOTPGroup>
-    <InputOTPSlot index={0} />
-    <InputOTPSlot index={1} />
-    <InputOTPSlot index={2} />
-    <InputOTPSlot index={3} />
-    <InputOTPSlot index={4} />
-    <InputOTPSlot index={5} />
-  </InputOTPGroup>
-</InputOTP>;
+import { Example } from "~/components/example";
+import { Field, FieldLabel } from "~/components/ui/field";
+import {
+  InputOTP,
+  InputOTPGroup,
+  InputOTPSeparator,
+  InputOTPSlot,
+} from "~/components/ui/input-otp";
 ```
 
-## Disabled
+```tsx file=../../registry/examples/input-otp-example.tsx#L76-L102
 
-Add the `disabled` prop to disable the entire input.
+```
 
-```tsx showLineNumbers
-<InputOTP maxLength={6} disabled>
-  <InputOTPGroup>
-    <InputOTPSlot index={0} />
-    <InputOTPSlot index={1} />
-    <InputOTPSlot index={2} />
-    <InputOTPSlot index={3} />
-    <InputOTPSlot index={4} />
-    <InputOTPSlot index={5} />
-  </InputOTPGroup>
-</InputOTP>
+### Alphanumeric
+
+```tsx
+import { Example } from "~/components/example";
+import { Field, FieldDescription, FieldLabel } from "~/components/ui/field";
+import {
+  InputOTP,
+  InputOTPGroup,
+  InputOTPSeparator,
+  InputOTPSlot,
+} from "~/components/ui/input-otp";
+```
+
+```tsx file=../../registry/examples/input-otp-example.tsx#L104-L126
+
+```
+
+### Disabled
+
+```tsx
+import { Example } from "~/components/example";
+import { Field, FieldLabel } from "~/components/ui/field";
+import {
+  InputOTP,
+  InputOTPGroup,
+  InputOTPSeparator,
+  InputOTPSlot,
+} from "~/components/ui/input-otp";
+```
+
+```tsx file=../../registry/examples/input-otp-example.tsx#L128-L149
+
+```
+
+### 4 Digits
+
+```tsx
+import { Example } from "~/components/example";
+import { Field, FieldDescription, FieldLabel } from "~/components/ui/field";
+import { InputOTP, InputOTPGroup, InputOTPSlot } from "~/components/ui/input-otp";
+```
+
+```tsx file=../../registry/examples/input-otp-example.tsx#L151-L168
+
+```
+
+### Invalid State
+
+```tsx
+import { createSignal } from "solid-js";
+import { Example } from "~/components/example";
+import { Field, FieldDescription, FieldError, FieldLabel } from "~/components/ui/field";
+import {
+  InputOTP,
+  InputOTPGroup,
+  InputOTPSeparator,
+  InputOTPSlot,
+} from "~/components/ui/input-otp";
+```
+
+```tsx file=../../registry/examples/input-otp-example.tsx#L170-L198
+
 ```

--- a/src/registry/examples/input-otp-example.tsx
+++ b/src/registry/examples/input-otp-example.tsx
@@ -80,7 +80,7 @@ function InputOTPWithSeparator() {
     <Example title="With Separator">
       <Field>
         <FieldLabel for="with-separator">With Separator</FieldLabel>
-        <InputOTP id="with-separator" maxLength={6} value={value()} onChange={setValue}>
+        <InputOTP id="with-separator" maxLength={6} value={value()} onValueChange={setValue}>
           <InputOTPGroup>
             <InputOTPSlot index={0} />
             <InputOTPSlot index={1} />
@@ -175,7 +175,7 @@ function InputOTPInvalid() {
       <Field>
         <FieldLabel for="invalid">Invalid State</FieldLabel>
         <FieldDescription>Example showing the invalid error state.</FieldDescription>
-        <InputOTP id="invalid" maxLength={6} value={value()} onChange={setValue}>
+        <InputOTP id="invalid" maxLength={6} value={value()} onValueChange={setValue}>
           <InputOTPGroup>
             <InputOTPSlot index={0} aria-invalid />
             <InputOTPSlot index={1} aria-invalid />
@@ -214,7 +214,7 @@ function InputOTPForm() {
               <div class="flex items-center justify-between">
                 <FieldLabel for="otp-verification">Verification code</FieldLabel>
                 <Button variant="outline" size="xs">
-                  <RefreshCcw />
+                  <RefreshCcw data-icon="inline-start" />
                   Resend Code
                 </Button>
               </div>

--- a/tests/input-otp.spec.ts
+++ b/tests/input-otp.spec.ts
@@ -1,0 +1,149 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Input OTP Examples", () => {
+  test("examples", async ({ page }) => {
+    await page.goto("/ui/input-otp");
+
+    await page.waitForLoadState("networkidle");
+
+    // ------------------------------------------------------------
+    // Form Example
+    // ------------------------------------------------------------
+
+    // 1. Verify the card title is visible
+    await expect(page.getByText("Verify your login")).toBeVisible();
+
+    // 2. Verify the email is displayed
+    await expect(page.getByText("m@example.com")).toBeVisible();
+
+    // 3. Verify the verification code input is visible
+    const formOtpInput = page.getByRole("textbox", { name: "Verification code" });
+    await expect(formOtpInput).toBeVisible();
+
+    // 4. Verify the Resend Code button is visible
+    await expect(page.getByRole("button", { name: "Resend Code" })).toBeVisible();
+
+    // 5. Verify the Verify button is visible
+    await expect(page.getByRole("button", { name: "Verify" })).toBeVisible();
+
+    // 6. Verify the Contact support link is visible
+    await expect(page.getByRole("link", { name: "Contact support" })).toBeVisible();
+
+    // ------------------------------------------------------------
+    // Simple Example
+    // ------------------------------------------------------------
+
+    // 7. Verify the Simple label is visible
+    await expect(page.getByText("Simple").first()).toBeVisible();
+
+    // 8. Verify the Simple input is visible
+    const simpleOtpInput = page.getByRole("textbox", { name: "Simple" });
+    await expect(simpleOtpInput).toBeVisible();
+
+    // ------------------------------------------------------------
+    // Digits Only Example
+    // ------------------------------------------------------------
+
+    // 9. Verify the Digits Only label is visible
+    await expect(page.getByText("Digits Only").first()).toBeVisible();
+
+    // 10. Verify the input is visible
+    const digitsOnlyOtpInput = page.getByRole("textbox", { name: "Digits Only" });
+    await expect(digitsOnlyOtpInput).toBeVisible();
+
+    // ------------------------------------------------------------
+    // With Separator Example
+    // ------------------------------------------------------------
+
+    // 11. Verify the With Separator label is visible
+    await expect(page.getByText("With Separator").first()).toBeVisible();
+
+    // 12. Verify the input is visible
+    const separatorOtpInput = page.getByRole("textbox", { name: "With Separator" });
+    await expect(separatorOtpInput).toBeVisible();
+
+    // ------------------------------------------------------------
+    // Alphanumeric Example
+    // ------------------------------------------------------------
+
+    // 13. Verify the Alphanumeric label is visible
+    await expect(page.getByText("Alphanumeric").first()).toBeVisible();
+
+    // 14. Verify the description is visible
+    await expect(page.getByText("Accepts both letters and numbers.")).toBeVisible();
+
+    // 15. Verify the input is visible
+    const alphanumericOtpInput = page.getByRole("textbox", { name: "Alphanumeric" });
+    await expect(alphanumericOtpInput).toBeVisible();
+
+    // ------------------------------------------------------------
+    // Disabled Example
+    // ------------------------------------------------------------
+
+    // 16. Verify the Disabled label is visible
+    await expect(page.getByText("Disabled").first()).toBeVisible();
+
+    // 17. Verify the input is visible and disabled
+    const disabledOtpInput = page.getByRole("textbox", { name: "Disabled" });
+    await expect(disabledOtpInput).toBeVisible();
+    await expect(disabledOtpInput).toBeDisabled();
+
+    // ------------------------------------------------------------
+    // 4 Digits Example
+    // ------------------------------------------------------------
+
+    // 18. Verify the 4 Digits label is visible
+    await expect(page.getByText("4 Digits").first()).toBeVisible();
+
+    // 19. Verify the description is visible
+    await expect(page.getByText("Common pattern for PIN codes.")).toBeVisible();
+
+    // 20. Verify the input is visible
+    const fourDigitsOtpInput = page.getByRole("textbox", { name: "4 Digits" });
+    await expect(fourDigitsOtpInput).toBeVisible();
+
+    // ------------------------------------------------------------
+    // Invalid State Example
+    // ------------------------------------------------------------
+
+    // 21. Verify the Invalid State label is visible
+    await expect(page.getByText("Invalid State").first()).toBeVisible();
+
+    // 22. Verify the description is visible
+    await expect(page.getByText("Example showing the invalid error state.")).toBeVisible();
+
+    // 23. Verify the input is visible
+    const invalidOtpInput = page.getByRole("textbox", { name: "Invalid State" });
+    await expect(invalidOtpInput).toBeVisible();
+
+    // 24. Verify the error message is visible
+    await expect(page.getByRole("alert")).toBeVisible();
+    await expect(page.getByText("Invalid code. Please try again.")).toBeVisible();
+
+    // ------------------------------------------------------------
+    // Docs Page Test - Toggle to Docs and Scroll
+    // ------------------------------------------------------------
+
+    // 25. Click the toggle button to switch to docs view
+    await page.getByRole("button", { name: "Toggle between preview and docs" }).click();
+
+    // 26. Verify the docs page is visible by checking for the main heading
+    await expect(page.getByRole("heading", { name: "Input OTP", level: 1 })).toBeVisible();
+
+    // 27. Verify the Installation section is present
+    await expect(page.getByRole("heading", { name: "Installation", level: 2 })).toBeVisible();
+
+    // 28. Verify the Usage section is present
+    await expect(page.getByRole("heading", { name: "Usage", level: 2 })).toBeVisible();
+
+    // 29. Verify the Examples section is present
+    await expect(page.getByRole("heading", { name: "Examples", level: 2 })).toBeVisible();
+
+    // 30. Scroll to the bottom to see all examples in docs
+    await page.keyboard.press("End");
+    await page.waitForTimeout(500);
+
+    // 31. Verify the Invalid State example heading is visible in docs
+    await expect(page.getByRole("heading", { name: "Invalid State", level: 3 })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

- Sync examples from Shadcn UI for input-otp component
- Transform React patterns to SolidJS (onChange → onValueChange)
- Update/create MDX documentation with Examples section
- Add Playwright test suite for visual validation

## Changes

- **src/registry/examples/input-otp-example.tsx**:
  - Fix `onChange` to `onValueChange` prop in controlled examples
  - Add `data-icon="inline-start"` attribute to RefreshCcw icon

- **src/pages/ui/input-otp.mdx**: Documentation with all examples

- **tests/input-otp.spec.ts**: New Playwright test suite covering:
  - Form example (card, buttons, links)
  - Simple, Digits Only, With Separator examples
  - Alphanumeric, Disabled, 4 Digits examples
  - Invalid State with error message
  - Docs page toggle and content verification

## Example Variants

| Example | Description |
|---------|-------------|
| Form | Full verification form with Card, buttons |
| Simple | Basic 6-digit OTP with separator |
| Digits Only | Digits-only pattern |
| With Separator | Pre-filled controlled input |
| Alphanumeric | Accepts letters and numbers |
| Disabled | Disabled state with pre-filled value |
| 4 Digits | PIN code pattern |
| Invalid State | Error state with validation message |

## Validation

- [x] Type checking passes
- [x] Playwright visual validation completed
- [x] Playwright test suite passes

## Video

[QA Video](https://okesuto.carere.dev/input-otp-qa-video.webm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)