### PR TITLE
feat(docs): sync combobox examples and documentation

### DIFF
--- a/src/pages/ui/combobox.mdx
+++ b/src/pages/ui/combobox.mdx
@@ -124,3 +124,309 @@ Used for grouping options when using `optionGroupChildren`.
 ### ComboboxSeparator
 
 Visual separator between groups.
+
+## Examples
+
+Here are the source code of all the examples from the preview page:
+
+### Basic
+
+```tsx
+import {
+  Combobox,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+} from "~/components/ui/combobox";
+```
+
+```tsx file=../../registry/examples/combobox-example.tsx#L64-L81
+
+```
+
+### Disabled
+
+```tsx
+import {
+  Combobox,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+} from "~/components/ui/combobox";
+```
+
+```tsx file=../../registry/examples/combobox-example.tsx#L83-L101
+
+```
+
+### Invalid
+
+```tsx
+import {
+  Combobox,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+} from "~/components/ui/combobox";
+import { Field, FieldDescription, FieldError, FieldLabel } from "~/components/ui/field";
+```
+
+```tsx file=../../registry/examples/combobox-example.tsx#L103-L145
+
+```
+
+### With Clear Button
+
+```tsx
+import {
+  Combobox,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+} from "~/components/ui/combobox";
+```
+
+```tsx file=../../registry/examples/combobox-example.tsx#L147-L165
+
+```
+
+### With Groups
+
+```tsx
+import { Show } from "solid-js";
+import {
+  Combobox,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxSection,
+  ComboboxSectionLabel,
+} from "~/components/ui/combobox";
+```
+
+```tsx file=../../registry/examples/combobox-example.tsx#L210-L235
+
+```
+
+### With Groups and Separator
+
+```tsx
+import { Show } from "solid-js";
+import {
+  Combobox,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxSection,
+  ComboboxSectionLabel,
+  ComboboxSeparator,
+} from "~/components/ui/combobox";
+```
+
+```tsx file=../../registry/examples/combobox-example.tsx#L237-L267
+
+```
+
+### Large List (100 items)
+
+```tsx
+import {
+  Combobox,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+} from "~/components/ui/combobox";
+```
+
+```tsx file=../../registry/examples/combobox-example.tsx#L274-L293
+
+```
+
+### With Icon Addon
+
+```tsx
+import { Globe } from "lucide-solid";
+import { Show } from "solid-js";
+import {
+  Combobox,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxSection,
+  ComboboxSectionLabel,
+  ComboboxSeparator,
+} from "~/components/ui/combobox";
+import { InputGroupAddon } from "~/components/ui/input-group";
+```
+
+```tsx file=../../registry/examples/combobox-example.tsx#L295-L329
+
+```
+
+### Form with Combobox
+
+```tsx
+import { toast } from "solid-sonner";
+import { Button } from "~/components/ui/button";
+import { Card, CardContent, CardFooter } from "~/components/ui/card";
+import {
+  Combobox,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+} from "~/components/ui/combobox";
+import { Field, FieldGroup, FieldLabel } from "~/components/ui/field";
+```
+
+```tsx file=../../registry/examples/combobox-example.tsx#L331-L375
+
+```
+
+### Multiple Selection
+
+```tsx
+import {
+  Combobox,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+} from "~/components/ui/combobox";
+```
+
+```tsx file=../../registry/examples/combobox-example.tsx#L377-L396
+
+```
+
+### Multiple Selection Disabled
+
+```tsx
+import {
+  Combobox,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+} from "~/components/ui/combobox";
+```
+
+```tsx file=../../registry/examples/combobox-example.tsx#L398-L418
+
+```
+
+### Multiple Selection Invalid
+
+```tsx
+import {
+  Combobox,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+} from "~/components/ui/combobox";
+import { Field, FieldDescription, FieldError, FieldLabel } from "~/components/ui/field";
+```
+
+```tsx file=../../registry/examples/combobox-example.tsx#L420-L466
+
+```
+
+### With Custom Item Rendering
+
+```tsx
+import {
+  Combobox,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+} from "~/components/ui/combobox";
+import { Item, ItemContent, ItemDescription, ItemTitle } from "~/components/ui/item";
+```
+
+```tsx file=../../registry/examples/combobox-example.tsx#L497-L525
+
+```
+
+### With Field
+
+```tsx
+import {
+  Combobox,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+} from "~/components/ui/combobox";
+import { Field, FieldDescription, FieldLabel } from "~/components/ui/field";
+```
+
+```tsx file=../../registry/examples/combobox-example.tsx#L527-L548
+
+```
+
+### In Dialog
+
+```tsx
+import { createSignal } from "solid-js";
+import { toast } from "solid-sonner";
+import { Button } from "~/components/ui/button";
+import {
+  Combobox,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+} from "~/components/ui/combobox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "~/components/ui/dialog";
+import { Field, FieldLabel } from "~/components/ui/field";
+```
+
+```tsx file=../../registry/examples/combobox-example.tsx#L550-L601
+
+```
+
+### With Other Inputs
+
+```tsx
+import { ChevronDown } from "lucide-solid";
+import { Button } from "~/components/ui/button";
+import {
+  Combobox,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+} from "~/components/ui/combobox";
+import { Input } from "~/components/ui/input";
+import { InputGroup, InputGroupAddon, InputGroupInput } from "~/components/ui/input-group";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "~/components/ui/select";
+```
+
+```tsx file=../../registry/examples/combobox-example.tsx#L614-L660
+
+```

--- a/src/registry/examples/combobox-example.tsx
+++ b/src/registry/examples/combobox-example.tsx
@@ -1,7 +1,9 @@
-import { Globe } from "lucide-solid";
+import { ChevronDown, Globe } from "lucide-solid";
 import { createSignal, Show } from "solid-js";
+import { toast } from "solid-sonner";
 import { Example, ExampleWrapper } from "@/components/example";
 import { Button } from "@/registry/ui/button";
+import { Card, CardContent, CardFooter } from "@/registry/ui/card";
 import {
   Combobox,
   ComboboxContent,
@@ -16,12 +18,23 @@ import {
   Dialog,
   DialogContent,
   DialogDescription,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
 } from "@/registry/ui/dialog";
-import { Field, FieldDescription, FieldLabel } from "@/registry/ui/field";
-import { InputGroupAddon } from "@/registry/ui/input-group";
+import { Field, FieldDescription, FieldError, FieldGroup, FieldLabel } from "@/registry/ui/field";
+import { Input } from "@/registry/ui/input";
+import { InputGroup, InputGroupAddon, InputGroupInput } from "@/registry/ui/input-group";
+import { Item, ItemContent, ItemDescription, ItemTitle } from "@/registry/ui/item";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/registry/ui/select";
 
 export default function ComboboxExample() {
   return (
@@ -31,11 +44,17 @@ export default function ComboboxExample() {
       <ComboboxInvalid />
       <ComboboxWithClear />
       <ComboboxWithGroups />
+      <ComboboxWithGroupsAndSeparator />
       <ComboboxLargeList />
       <ComboboxWithIconAddon />
+      <ComboboxWithForm />
       <ComboboxMultiple />
+      <ComboboxMultipleDisabled />
+      <ComboboxMultipleInvalid />
+      <ComboboxWithCustomItems />
       <ComboboxWithField />
       <ComboboxInDialog />
+      <ComboboxWithOtherInputs />
     </ExampleWrapper>
   );
 }
@@ -84,19 +103,43 @@ function ComboboxDisabled() {
 function ComboboxInvalid() {
   return (
     <Example title="Invalid">
-      <Combobox
-        options={frameworks}
-        placeholder="Select a framework..."
-        validationState="invalid"
-        itemComponent={(props) => (
-          <ComboboxItem item={props.item}>{props.item.rawValue}</ComboboxItem>
-        )}
-      >
-        <ComboboxInput placeholder="Select a framework..." aria-invalid="true" />
-        <ComboboxContent>
-          <ComboboxEmpty>No frameworks found.</ComboboxEmpty>
-        </ComboboxContent>
-      </Combobox>
+      <div class="flex flex-col gap-4">
+        <Combobox
+          options={frameworks}
+          placeholder="Select a framework..."
+          validationState="invalid"
+          itemComponent={(props) => (
+            <ComboboxItem item={props.item}>{props.item.rawValue}</ComboboxItem>
+          )}
+        >
+          <ComboboxInput placeholder="Select a framework..." aria-invalid="true" />
+          <ComboboxContent>
+            <ComboboxEmpty>No frameworks found.</ComboboxEmpty>
+          </ComboboxContent>
+        </Combobox>
+        <Field data-invalid>
+          <FieldLabel for="combobox-framework-invalid">Framework</FieldLabel>
+          <Combobox
+            options={frameworks}
+            placeholder="Select a framework..."
+            validationState="invalid"
+            itemComponent={(props) => (
+              <ComboboxItem item={props.item}>{props.item.rawValue}</ComboboxItem>
+            )}
+          >
+            <ComboboxInput
+              id="combobox-framework-invalid"
+              placeholder="Select a framework..."
+              aria-invalid="true"
+            />
+            <ComboboxContent>
+              <ComboboxEmpty>No frameworks found.</ComboboxEmpty>
+            </ComboboxContent>
+          </Combobox>
+          <FieldDescription>Please select a valid framework.</FieldDescription>
+          <FieldError errors={[{ message: "This field is required." }]} />
+        </Field>
+      </div>
     </Example>
   );
 }
@@ -137,7 +180,7 @@ const timezones: TimezoneGroup[] = [
       "(GMT-6) Chicago",
       "(GMT-5) Toronto",
       "(GMT-8) Vancouver",
-      "(GMT-3) Sao Paulo",
+      "(GMT-3) São Paulo",
     ],
   },
   {
@@ -167,6 +210,33 @@ const timezones: TimezoneGroup[] = [
 function ComboboxWithGroups() {
   return (
     <Example title="With Groups">
+      <Combobox<TimezoneOption, TimezoneGroup>
+        options={timezones}
+        optionValue={(opt) => opt}
+        optionTextValue={(opt) => opt}
+        optionGroupChildren="options"
+        placeholder="Select a timezone..."
+        itemComponent={(props) => (
+          <ComboboxItem item={props.item}>{props.item.rawValue}</ComboboxItem>
+        )}
+        sectionComponent={(props) => (
+          <ComboboxSection>
+            <ComboboxSectionLabel>{props.section.rawValue.label}</ComboboxSectionLabel>
+          </ComboboxSection>
+        )}
+      >
+        <ComboboxInput placeholder="Select a timezone..." />
+        <ComboboxContent>
+          <ComboboxEmpty>No timezones found.</ComboboxEmpty>
+        </ComboboxContent>
+      </Combobox>
+    </Example>
+  );
+}
+
+function ComboboxWithGroupsAndSeparator() {
+  return (
+    <Example title="With Groups and Separator">
       <Combobox<TimezoneOption, TimezoneGroup>
         options={timezones}
         optionValue={(opt) => opt}
@@ -258,6 +328,52 @@ function ComboboxWithIconAddon() {
   );
 }
 
+function ComboboxWithForm() {
+  const handleSubmit = (event: SubmitEvent) => {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget as HTMLFormElement);
+    const framework = formData.get("framework") as string;
+    toast(`You selected ${framework} as your framework.`);
+  };
+
+  return (
+    <Example title="Form with Combobox">
+      <Card class="w-full max-w-sm" size="sm">
+        <CardContent>
+          <form id="form-with-combobox" class="w-full" onSubmit={handleSubmit}>
+            <FieldGroup>
+              <Field>
+                <FieldLabel for="framework">Framework</FieldLabel>
+                <Combobox
+                  options={frameworks}
+                  placeholder="Select a framework..."
+                  itemComponent={(props) => (
+                    <ComboboxItem item={props.item}>{props.item.rawValue}</ComboboxItem>
+                  )}
+                >
+                  <ComboboxInput
+                    id="framework"
+                    name="framework"
+                    placeholder="Select a framework..."
+                  />
+                  <ComboboxContent>
+                    <ComboboxEmpty>No items found.</ComboboxEmpty>
+                  </ComboboxContent>
+                </Combobox>
+              </Field>
+            </FieldGroup>
+          </form>
+        </CardContent>
+        <CardFooter>
+          <Button type="submit" form="form-with-combobox">
+            Submit
+          </Button>
+        </CardFooter>
+      </Card>
+    </Example>
+  );
+}
+
 function ComboboxMultiple() {
   return (
     <Example title="Multiple Selection">
@@ -273,6 +389,135 @@ function ComboboxMultiple() {
         <ComboboxInput placeholder="Select frameworks..." />
         <ComboboxContent>
           <ComboboxEmpty>No frameworks found.</ComboboxEmpty>
+        </ComboboxContent>
+      </Combobox>
+    </Example>
+  );
+}
+
+function ComboboxMultipleDisabled() {
+  return (
+    <Example title="Multiple Selection Disabled">
+      <Combobox<(typeof frameworks)[number]>
+        options={frameworks}
+        placeholder="Select frameworks..."
+        multiple
+        disabled
+        defaultValue={[frameworks[0], frameworks[1]]}
+        itemComponent={(props) => (
+          <ComboboxItem item={props.item}>{props.item.rawValue}</ComboboxItem>
+        )}
+      >
+        <ComboboxInput placeholder="Select frameworks..." disabled />
+        <ComboboxContent>
+          <ComboboxEmpty>No frameworks found.</ComboboxEmpty>
+        </ComboboxContent>
+      </Combobox>
+    </Example>
+  );
+}
+
+function ComboboxMultipleInvalid() {
+  return (
+    <Example title="Multiple Selection Invalid">
+      <div class="flex flex-col gap-4">
+        <Combobox<(typeof frameworks)[number]>
+          options={frameworks}
+          placeholder="Select frameworks..."
+          multiple
+          validationState="invalid"
+          defaultValue={[frameworks[0], frameworks[1]]}
+          itemComponent={(props) => (
+            <ComboboxItem item={props.item}>{props.item.rawValue}</ComboboxItem>
+          )}
+        >
+          <ComboboxInput placeholder="Select frameworks..." aria-invalid="true" />
+          <ComboboxContent>
+            <ComboboxEmpty>No frameworks found.</ComboboxEmpty>
+          </ComboboxContent>
+        </Combobox>
+        <Field data-invalid>
+          <FieldLabel for="combobox-multiple-invalid">Frameworks</FieldLabel>
+          <Combobox<(typeof frameworks)[number]>
+            options={frameworks}
+            placeholder="Select frameworks..."
+            multiple
+            validationState="invalid"
+            defaultValue={[frameworks[0], frameworks[1], frameworks[2]]}
+            itemComponent={(props) => (
+              <ComboboxItem item={props.item}>{props.item.rawValue}</ComboboxItem>
+            )}
+          >
+            <ComboboxInput
+              id="combobox-multiple-invalid"
+              placeholder="Select frameworks..."
+              aria-invalid="true"
+            />
+            <ComboboxContent>
+              <ComboboxEmpty>No frameworks found.</ComboboxEmpty>
+            </ComboboxContent>
+          </Combobox>
+          <FieldDescription>Please select at least one framework.</FieldDescription>
+          <FieldError errors={[{ message: "This field is required." }]} />
+        </Field>
+      </div>
+    </Example>
+  );
+}
+
+const countries = [
+  { code: "af", value: "afghanistan", label: "Afghanistan", continent: "Asia" },
+  { code: "al", value: "albania", label: "Albania", continent: "Europe" },
+  { code: "dz", value: "algeria", label: "Algeria", continent: "Africa" },
+  { code: "ad", value: "andorra", label: "Andorra", continent: "Europe" },
+  { code: "ao", value: "angola", label: "Angola", continent: "Africa" },
+  { code: "ar", value: "argentina", label: "Argentina", continent: "South America" },
+  { code: "am", value: "armenia", label: "Armenia", continent: "Asia" },
+  { code: "au", value: "australia", label: "Australia", continent: "Oceania" },
+  { code: "at", value: "austria", label: "Austria", continent: "Europe" },
+  { code: "az", value: "azerbaijan", label: "Azerbaijan", continent: "Asia" },
+  { code: "bs", value: "bahamas", label: "Bahamas", continent: "North America" },
+  { code: "bh", value: "bahrain", label: "Bahrain", continent: "Asia" },
+  { code: "bd", value: "bangladesh", label: "Bangladesh", continent: "Asia" },
+  { code: "bb", value: "barbados", label: "Barbados", continent: "North America" },
+  { code: "by", value: "belarus", label: "Belarus", continent: "Europe" },
+  { code: "be", value: "belgium", label: "Belgium", continent: "Europe" },
+  { code: "br", value: "brazil", label: "Brazil", continent: "South America" },
+  { code: "ca", value: "canada", label: "Canada", continent: "North America" },
+  { code: "cn", value: "china", label: "China", continent: "Asia" },
+  { code: "fr", value: "france", label: "France", continent: "Europe" },
+  { code: "de", value: "germany", label: "Germany", continent: "Europe" },
+  { code: "in", value: "india", label: "India", continent: "Asia" },
+  { code: "jp", value: "japan", label: "Japan", continent: "Asia" },
+  { code: "mx", value: "mexico", label: "Mexico", continent: "North America" },
+  { code: "gb", value: "united-kingdom", label: "United Kingdom", continent: "Europe" },
+  { code: "us", value: "united-states", label: "United States", continent: "North America" },
+];
+
+function ComboboxWithCustomItems() {
+  return (
+    <Example title="With Custom Item Rendering">
+      <Combobox<(typeof countries)[number]>
+        options={countries}
+        optionValue="value"
+        optionTextValue="label"
+        placeholder="Search countries..."
+        itemComponent={(props) => (
+          <ComboboxItem item={props.item}>
+            <Item size="xs" class="p-0">
+              <ItemContent>
+                <ItemTitle class="whitespace-nowrap">{props.item.rawValue.label}</ItemTitle>
+                <ItemDescription>
+                  {props.item.rawValue.continent} ({props.item.rawValue.code})
+                </ItemDescription>
+              </ItemContent>
+            </Item>
+          </ComboboxItem>
+        )}
+      >
+        <ComboboxInput placeholder="Search countries..." />
+        <ComboboxContent>
+          <ComboboxEmpty>No countries found.</ComboboxEmpty>
         </ComboboxContent>
       </Combobox>
     </Example>
@@ -311,27 +556,105 @@ function ComboboxInDialog() {
         <DialogTrigger as={Button} variant="outline">
           Open Dialog
         </DialogTrigger>
-        <DialogContent>
+        <DialogContent class="sm:max-w-[425px]">
           <DialogHeader>
             <DialogTitle>Select Framework</DialogTitle>
             <DialogDescription>
               Choose your preferred framework from the list below.
             </DialogDescription>
           </DialogHeader>
-          <Combobox
-            options={frameworks}
-            placeholder="Select a framework..."
-            itemComponent={(props) => (
-              <ComboboxItem item={props.item}>{props.item.rawValue}</ComboboxItem>
-            )}
-          >
-            <ComboboxInput placeholder="Select a framework..." />
-            <ComboboxContent>
-              <ComboboxEmpty>No frameworks found.</ComboboxEmpty>
-            </ComboboxContent>
-          </Combobox>
+          <Field>
+            <FieldLabel for="framework-dialog" class="sr-only">
+              Framework
+            </FieldLabel>
+            <Combobox
+              options={frameworks}
+              placeholder="Select a framework..."
+              itemComponent={(props) => (
+                <ComboboxItem item={props.item}>{props.item.rawValue}</ComboboxItem>
+              )}
+            >
+              <ComboboxInput id="framework-dialog" placeholder="Select a framework..." />
+              <ComboboxContent>
+                <ComboboxEmpty>No frameworks found.</ComboboxEmpty>
+              </ComboboxContent>
+            </Combobox>
+          </Field>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              onClick={() => {
+                toast("Framework selected.");
+                setOpen(false);
+              }}
+            >
+              Confirm
+            </Button>
+          </DialogFooter>
         </DialogContent>
       </Dialog>
+    </Example>
+  );
+}
+
+const selectItems = [
+  { label: "Select a framework", value: "" },
+  { label: "React", value: "react" },
+  { label: "Vue", value: "vue" },
+  { label: "Angular", value: "angular" },
+  { label: "Svelte", value: "svelte" },
+  { label: "Solid", value: "solid" },
+  { label: "Preact", value: "preact" },
+  { label: "Next.js", value: "next.js" },
+];
+
+function ComboboxWithOtherInputs() {
+  return (
+    <Example title="With Other Inputs">
+      <Combobox
+        options={frameworks}
+        placeholder="Select a framework..."
+        itemComponent={(props) => (
+          <ComboboxItem item={props.item}>{props.item.rawValue}</ComboboxItem>
+        )}
+      >
+        <ComboboxInput class="w-52" placeholder="Select a framework..." />
+        <ComboboxContent>
+          <ComboboxEmpty>No frameworks found.</ComboboxEmpty>
+        </ComboboxContent>
+      </Combobox>
+      <Select<(typeof selectItems)[number]>
+        options={selectItems}
+        optionValue="value"
+        optionTextValue="label"
+        defaultValue={selectItems[0]}
+        itemComponent={(props) => (
+          <SelectItem item={props.item}>{props.item.rawValue.label}</SelectItem>
+        )}
+      >
+        <SelectTrigger class="w-52">
+          <SelectValue<(typeof selectItems)[number]>>
+            {(state) => state.selectedOption()?.label}
+          </SelectValue>
+        </SelectTrigger>
+        <SelectContent>
+          <SelectGroup />
+        </SelectContent>
+      </Select>
+      <Button variant="outline" class="w-52 justify-between font-normal text-muted-foreground">
+        Select a framework
+        <ChevronDown class="size-4" />
+      </Button>
+      <Input placeholder="Select a framework" class="w-52" />
+      <InputGroup class="w-52">
+        <InputGroupInput placeholder="Select a framework" />
+        <InputGroupAddon align="inline-end">
+          <ChevronDown class="size-4" />
+        </InputGroupAddon>
+      </InputGroup>
     </Example>
   );
 }


### PR DESCRIPTION
## Summary

- Sync 16 combobox examples from Shadcn UI
- Transform React patterns to SolidJS
- Update MDX documentation with Examples section

## Examples Added

| Example | Description |
|---------|-------------|
| Basic | Simple combobox with framework options |
| Disabled | Combobox in disabled state |
| Invalid | Combobox with validation error states |
| With Clear Button | Combobox with clear functionality |
| With Groups | Timezone selection with grouped options |
| With Groups and Separator | Groups with visual separators |
| Large List (100 items) | Performance test with many items |
| With Icon Addon | Globe icon prefix for timezone |
| Form with Combobox | Integration with Card and form submission |
| Multiple Selection | Multi-select combobox |
| Multiple Selection Disabled | Disabled multi-select state |
| Multiple Selection Invalid | Multi-select with validation errors |
| With Custom Item Rendering | Countries with Item component |
| With Field | Integration with Field component |
| In Dialog | Combobox inside a Dialog |
| With Other Inputs | Comparison with Select, Input, etc. |

## Validation

- [x] Biome lint and format passes
- [x] Playwright visual validation completed
- [x] All 16 examples render correctly

## Files Changed

- `src/registry/examples/combobox-example.tsx` - Component examples (16 variants)
- `src/pages/ui/combobox.mdx` - Documentation with Examples section

---
🤖 Generated with [Claude Code](https://claude.ai/code)