### PR TITLE
feat(docs): sync empty examples and documentation

### DIFF
--- a/src/pages/ui/empty.mdx
+++ b/src/pages/ui/empty.mdx
@@ -1,12 +1,12 @@
 ---
 title: Empty
 slug: empty
-description: A composable empty state for when there is no data to display.
+description: Use the Empty component to display an empty state.
 ---
 
 # Empty
 
-A composable empty state for when there is no data to display.
+Use the Empty component to display an empty state.
 
 ## Installation
 
@@ -41,26 +41,129 @@ import {
 <Empty>
   <EmptyHeader>
     <EmptyMedia variant="icon">
-      <FolderIcon class="size-10" />
+      <Icon />
     </EmptyMedia>
-    <EmptyTitle>No projects yet</EmptyTitle>
-    <EmptyDescription>
-      You haven't created any projects yet. Get started by creating your first project.
-    </EmptyDescription>
+    <EmptyTitle>No data</EmptyTitle>
+    <EmptyDescription>No data found</EmptyDescription>
   </EmptyHeader>
   <EmptyContent>
-    <Button>Create project</Button>
+    <Button>Add data</Button>
   </EmptyContent>
 </Empty>
 ```
 
-## Structure
+## Examples
 
-The Empty component is composed of several sub-components:
+Here are the source code of all the examples from the preview page:
 
-- `Empty` - The main container
-- `EmptyHeader` - Contains the media, title, and description
-- `EmptyMedia` - Displays an icon, image, or avatar (with "icon" and "default" variants)
-- `EmptyTitle` - The heading text
-- `EmptyDescription` - Supporting descriptive text
-- `EmptyContent` - Action area for buttons, inputs, or links
+### Basic
+
+```tsx
+import { ArrowUpRight } from "lucide-solid";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle,
+} from "~/components/ui/empty";
+import { Button } from "~/components/ui/button";
+```
+
+```tsx file=../../registry/examples/empty-example.tsx#L29-L53
+
+```
+
+### With Muted Background
+
+```tsx
+import { ArrowUpRight } from "lucide-solid";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle,
+} from "~/components/ui/empty";
+import { Button } from "~/components/ui/button";
+```
+
+```tsx file=../../registry/examples/empty-example.tsx#L55-L74
+
+```
+
+### With Border
+
+```tsx
+import { CircleDashed } from "lucide-solid";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle,
+} from "~/components/ui/empty";
+import { InputGroup, InputGroupAddon, InputGroupInput } from "~/components/ui/input-group";
+import { Kbd } from "~/components/ui/kbd";
+```
+
+```tsx file=../../registry/examples/empty-example.tsx#L76-L104
+
+```
+
+### With Icon
+
+```tsx
+import { Folder, Plus } from "lucide-solid";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "~/components/ui/empty";
+import { Button } from "~/components/ui/button";
+```
+
+```tsx file=../../registry/examples/empty-example.tsx#L106-L128
+
+```
+
+### With Muted Background Alt
+
+```tsx
+import { CircleDashed } from "lucide-solid";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle,
+} from "~/components/ui/empty";
+import { InputGroup, InputGroupAddon, InputGroupInput } from "~/components/ui/input-group";
+import { Kbd } from "~/components/ui/kbd";
+```
+
+```tsx file=../../registry/examples/empty-example.tsx#L130-L158
+
+```
+
+### In Card
+
+```tsx
+import { ArrowUpRight, Folder } from "lucide-solid";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "~/components/ui/empty";
+import { Button } from "~/components/ui/button";
+```
+
+```tsx file=../../registry/examples/empty-example.tsx#L160-L187
+
+```

--- a/src/registry/examples/empty-example.tsx
+++ b/src/registry/examples/empty-example.tsx
@@ -1,5 +1,5 @@
 /** biome-ignore-all lint/a11y/useValidAnchor: <example file> */
-import { ArrowUpRight, CircleDashed, FolderIcon, Plus } from "lucide-solid";
+import { ArrowUpRight, CircleDashed, Folder, Plus } from "lucide-solid";
 import { Example, ExampleWrapper } from "@/components/example";
 import { Button } from "@/registry/ui/button";
 import {
@@ -10,8 +10,8 @@ import {
   EmptyMedia,
   EmptyTitle,
 } from "@/registry/ui/empty";
-import { InputGroup, InputGroupAddon, InputGroupInput } from "../ui/input-group";
-import { Kbd } from "../ui/kbd";
+import { InputGroup, InputGroupAddon, InputGroupInput } from "@/registry/ui/input-group";
+import { Kbd } from "@/registry/ui/kbd";
 
 export default function EmptyExample() {
   return (
@@ -109,7 +109,7 @@ function EmptyWithIcon() {
       <Empty class="border">
         <EmptyHeader>
           <EmptyMedia variant="icon">
-            <FolderIcon />
+            <Folder />
           </EmptyMedia>
           <EmptyTitle>Nothing to see here</EmptyTitle>
           <EmptyDescription>
@@ -163,7 +163,7 @@ function EmptyInCard() {
       <Empty>
         <EmptyHeader>
           <EmptyMedia variant="icon">
-            <FolderIcon />
+            <Folder />
           </EmptyMedia>
           <EmptyTitle>No projects yet</EmptyTitle>
           <EmptyDescription>

--- a/tests/empty.spec.ts
+++ b/tests/empty.spec.ts
@@ -1,0 +1,195 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Empty Component", () => {
+  test("examples", async ({ page }) => {
+    await page.goto("http://localhost:5174/ui/empty");
+
+    await page.waitForLoadState("networkidle");
+
+    // ------------------------------------------------------------
+    // Basic Example
+    // ------------------------------------------------------------
+
+    // 1. Get the basic section
+    const basicSection = page.getByText("Basic", { exact: true }).locator("..");
+
+    // 2. Verify the basic example is visible
+    await expect(basicSection).toBeVisible();
+
+    // 3. Verify the title "No projects yet" is visible
+    await expect(basicSection.getByText("No projects yet")).toBeVisible();
+
+    // 4. Verify the description is visible
+    await expect(basicSection.getByText("You haven't created any projects yet.")).toBeVisible();
+
+    // 5. Hover over the 'Create project' link
+    await basicSection.getByRole("link", { name: "Create project", exact: true }).hover();
+
+    // 6. Wait for 300ms to simulate user navigation
+    await page.waitForTimeout(300);
+
+    // 7. Verify the 'Import project' button is visible
+    await expect(
+      basicSection.getByRole("button", { name: "Import project", exact: true }),
+    ).toBeVisible();
+
+    // 8. Hover over the 'Learn more' link
+    await basicSection.getByRole("link", { name: "Learn more" }).hover();
+
+    // 9. Wait for 300ms to simulate user navigation
+    await page.waitForTimeout(300);
+
+    // ------------------------------------------------------------
+    // With Muted Background Example
+    // ------------------------------------------------------------
+
+    // 10. Get the with muted background section
+    const mutedSection = page.getByText("With Muted Background", { exact: true }).locator("..");
+
+    // 11. Verify the section is visible
+    await expect(mutedSection).toBeVisible();
+
+    // 12. Verify the title "No results found" is visible
+    await expect(mutedSection.getByText("No results found", { exact: true })).toBeVisible();
+
+    // 13. Hover over the 'Try again' button
+    await mutedSection.getByRole("button", { name: "Try again", exact: true }).hover();
+
+    // 14. Wait for 300ms to simulate user navigation
+    await page.waitForTimeout(300);
+
+    // ------------------------------------------------------------
+    // With Border Example
+    // ------------------------------------------------------------
+
+    // 15. Get the with border section
+    const borderSection = page.getByText("With Border", { exact: true }).locator("..");
+
+    // 16. Verify the section is visible
+    await expect(borderSection).toBeVisible();
+
+    // 17. Verify the title "404 - Not Found" is visible
+    await expect(borderSection.getByText("404 - Not Found", { exact: true })).toBeVisible();
+
+    // 18. Verify the search input is visible
+    await expect(
+      borderSection.getByPlaceholder("Try searching for pages...").first(),
+    ).toBeVisible();
+
+    // 19. Click on the search input
+    await borderSection.getByPlaceholder("Try searching for pages...").first().click();
+
+    // 20. Type in the search input
+    await borderSection.getByPlaceholder("Try searching for pages...").first().fill("test search");
+
+    // 21. Wait for 300ms
+    await page.waitForTimeout(300);
+
+    // 22. Clear the input
+    await borderSection.getByPlaceholder("Try searching for pages...").first().clear();
+
+    // 23. Hover over the 'Contact support' link
+    await borderSection.getByRole("link", { name: "Contact support" }).hover();
+
+    // 24. Wait for 300ms to simulate user navigation
+    await page.waitForTimeout(300);
+
+    // ------------------------------------------------------------
+    // With Icon Example
+    // ------------------------------------------------------------
+
+    // 25. Get the with icon section
+    const iconSection = page.getByText("With Icon", { exact: true }).locator("..");
+
+    // 26. Verify the section is visible
+    await expect(iconSection).toBeVisible();
+
+    // 27. Verify the title "Nothing to see here" is visible
+    await expect(iconSection.getByText("Nothing to see here")).toBeVisible();
+
+    // 28. Hover over the 'New Post' button
+    await iconSection.getByRole("button", { name: "New Post", exact: true }).hover();
+
+    // 29. Wait for 300ms to simulate user navigation
+    await page.waitForTimeout(300);
+
+    // 30. Verify the 'creating your first post' link is visible
+    await expect(iconSection.getByRole("link", { name: "creating your first post" })).toBeVisible();
+
+    // ------------------------------------------------------------
+    // With Muted Background Alt Example
+    // ------------------------------------------------------------
+
+    // 31. Get the with muted background alt section
+    const mutedAltSection = page
+      .getByText("With Muted Background Alt", { exact: true })
+      .locator("..");
+
+    // 32. Verify the section is visible
+    await expect(mutedAltSection).toBeVisible();
+
+    // 33. Verify the title "404 - Not Found" is visible
+    await expect(mutedAltSection.getByText("404 - Not Found", { exact: true })).toBeVisible();
+
+    // 34. Verify the search input is visible
+    await expect(
+      mutedAltSection.getByPlaceholder("Try searching for pages...").first(),
+    ).toBeVisible();
+
+    // ------------------------------------------------------------
+    // In Card Example
+    // ------------------------------------------------------------
+
+    // 35. Get the in card section
+    const cardSection = page.getByText("In Card", { exact: true }).locator("..");
+
+    // 36. Verify the section is visible
+    await expect(cardSection).toBeVisible();
+
+    // 37. Verify the title "No projects yet" is visible
+    await expect(cardSection.getByText("No projects yet")).toBeVisible();
+
+    // 38. Hover over the 'Create project' link
+    await cardSection.getByRole("link", { name: "Create project", exact: true }).hover();
+
+    // 39. Wait for 300ms to simulate user navigation
+    await page.waitForTimeout(300);
+
+    // 40. Hover over the 'Import project' button
+    await cardSection.getByRole("button", { name: "Import project", exact: true }).hover();
+
+    // 41. Wait for 300ms to simulate user navigation
+    await page.waitForTimeout(300);
+
+    // ------------------------------------------------------------
+    // Docs Page Test - Toggle to Docs and Scroll
+    // ------------------------------------------------------------
+
+    // 42. Click the toggle button to switch to docs view
+    await page.getByRole("button", { name: "Toggle between preview and docs" }).click();
+
+    // 43. Wait for docs to load
+    await page.waitForTimeout(500);
+
+    // 44. Verify the docs page is visible by checking for the main heading
+    await expect(page.getByRole("heading", { name: "Empty", level: 1 })).toBeVisible();
+
+    // 45. Verify the Installation section is present
+    await expect(page.getByRole("heading", { name: "Installation", level: 2 })).toBeVisible();
+
+    // 46. Verify the Usage section is present
+    await expect(page.getByRole("heading", { name: "Usage", level: 2 })).toBeVisible();
+
+    // 47. Verify the Examples section is present
+    await expect(page.getByRole("heading", { name: "Examples", level: 2 })).toBeVisible();
+
+    // 48. Scroll to the bottom to verify all examples are present
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+
+    // 49. Wait for scroll animation
+    await page.waitForTimeout(300);
+
+    // 50. Verify the "In Card" example heading is visible in docs
+    await expect(page.getByRole("heading", { name: "In Card", level: 3 })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

- Sync examples from Shadcn UI for empty component
- Transform React patterns to SolidJS
- Update MDX documentation with Examples section

## Changes

- Updated `src/registry/examples/empty-example.tsx` with proper alias imports (`@/registry/ui/` instead of relative paths)
- Updated `src/pages/ui/empty.mdx` with comprehensive Examples section including all 6 example variants
- Added Playwright test suite `tests/empty.spec.ts` for visual validation

## Example Variants

| Example | Description |
|---------|-------------|
| Basic | Simple empty state with title, description, and action buttons |
| With Muted Background | Empty state with muted background styling |
| With Border | Empty state with border and search input |
| With Icon | Empty state with icon media and action button |
| With Muted Background Alt | Alternate muted background with search input |
| In Card | Empty state styled for card context |

## Validation

- [x] Type checking passes (no new errors)
- [x] Playwright visual validation completed
- [x] Playwright test suite passes

## Video

[QA Video](https://okesuto.carere.dev/empty-qa-video.webm)

## Files Changed

- `src/registry/examples/empty-example.tsx` - Component examples
- `src/pages/ui/empty.mdx` - Documentation
- `tests/empty.spec.ts` - Playwright test suite