### PR TITLE
feat(docs): sync collapsible examples and documentation

### DIFF
--- a/src/pages/ui/collapsible.mdx
+++ b/src/pages/ui/collapsible.mdx
@@ -1,0 +1,87 @@
+---
+title: Collapsible
+slug: collapsible
+description: An interactive component which expands/collapses a panel.
+---
+
+# Collapsible
+
+An interactive component which expands/collapses a panel.
+
+## Installation
+
+### CLI
+
+```package-dlx
+shadcn@latest add collapsible
+```
+
+### Manual
+
+Copy and paste the following code into your project.
+
+```tsx file=../../registry/ui/collapsible.tsx showLineNumbers
+
+```
+
+## Usage
+
+```tsx
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "~/components/ui/collapsible";
+```
+
+```tsx showLineNumbers
+<Collapsible>
+  <CollapsibleTrigger>Can I use this in my project?</CollapsibleTrigger>
+  <CollapsibleContent>
+    Yes. Free to use for personal and commercial projects. No attribution
+    required.
+  </CollapsibleContent>
+</Collapsible>
+```
+
+## Examples
+
+Here are the source code of all the examples from the preview page:
+
+### File Tree
+
+```tsx
+import { ChevronRight, File, Folder } from "lucide-solid";
+import { Button } from "~/components/ui/button";
+import { Card, CardContent, CardHeader } from "~/components/ui/card";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "~/components/ui/collapsible";
+import { Tabs, TabsList, TabsTrigger } from "~/components/ui/tabs";
+```
+
+```tsx file=../../registry/examples/collapsible-example.tsx#L22-L118
+
+```
+
+### Settings
+
+```tsx
+import { Maximize, Minimize } from "lucide-solid";
+import { createSignal, Show } from "solid-js";
+import { Button } from "~/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "~/components/ui/card";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "~/components/ui/collapsible";
+import { Field, FieldGroup, FieldLabel } from "~/components/ui/field";
+import { Input } from "~/components/ui/input";
+```
+
+```tsx file=../../registry/examples/collapsible-example.tsx#L120-L170
+
+```

--- a/src/registry/examples/collapsible-example.tsx
+++ b/src/registry/examples/collapsible-example.tsx
@@ -1,0 +1,170 @@
+import { ChevronRight, File, Folder, Maximize, Minimize } from "lucide-solid";
+import { createSignal, Show } from "solid-js";
+import { Example, ExampleWrapper } from "@/components/example";
+import { Button } from "@/registry/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/registry/ui/card";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/registry/ui/collapsible";
+import { Field, FieldGroup, FieldLabel } from "@/registry/ui/field";
+import { Input } from "@/registry/ui/input";
+import { Tabs, TabsList, TabsTrigger } from "@/registry/ui/tabs";
+
+export default function CollapsibleExample() {
+  return (
+    <ExampleWrapper>
+      <CollapsibleFileTree />
+      <CollapsibleSettings />
+    </ExampleWrapper>
+  );
+}
+
+type FileTreeItem = { name: string } | { name: string; items: FileTreeItem[] };
+
+function CollapsibleFileTree() {
+  const fileTree: FileTreeItem[] = [
+    {
+      name: "components",
+      items: [
+        {
+          name: "ui",
+          items: [
+            { name: "button.tsx" },
+            { name: "card.tsx" },
+            { name: "dialog.tsx" },
+            { name: "input.tsx" },
+            { name: "select.tsx" },
+            { name: "table.tsx" },
+          ],
+        },
+        { name: "login-form.tsx" },
+        { name: "register-form.tsx" },
+      ],
+    },
+    {
+      name: "lib",
+      items: [{ name: "utils.ts" }, { name: "cn.ts" }, { name: "api.ts" }],
+    },
+    {
+      name: "hooks",
+      items: [
+        { name: "use-media-query.ts" },
+        { name: "use-debounce.ts" },
+        { name: "use-local-storage.ts" },
+      ],
+    },
+    {
+      name: "types",
+      items: [{ name: "index.d.ts" }, { name: "api.d.ts" }],
+    },
+    {
+      name: "public",
+      items: [{ name: "favicon.ico" }, { name: "logo.svg" }, { name: "images" }],
+    },
+    { name: "app.tsx" },
+    { name: "layout.tsx" },
+    { name: "globals.css" },
+    { name: "package.json" },
+    { name: "tsconfig.json" },
+    { name: "README.md" },
+    { name: ".gitignore" },
+  ];
+
+  const renderItem = (fileItem: FileTreeItem) => {
+    if ("items" in fileItem) {
+      return (
+        <Collapsible>
+          <CollapsibleTrigger
+            as={Button}
+            variant="ghost"
+            size="sm"
+            class="group w-full justify-start transition-none hover:bg-accent hover:text-accent-foreground"
+          >
+            <ChevronRight class="transition-transform group-data-[expanded]:rotate-90" />
+            <Folder />
+            {fileItem.name}
+          </CollapsibleTrigger>
+          <CollapsibleContent class="mt-1 ml-5 style-lyra:ml-4">
+            <div class="flex flex-col gap-1">
+              {fileItem.items.map((child) => renderItem(child))}
+            </div>
+          </CollapsibleContent>
+        </Collapsible>
+      );
+    }
+    return (
+      <Button variant="link" size="sm" class="w-full justify-start gap-2 text-foreground">
+        <File />
+        <span>{fileItem.name}</span>
+      </Button>
+    );
+  };
+
+  return (
+    <Example title="File Tree" class="items-center">
+      <Card class="mx-auto w-full max-w-[16rem] gap-2" size="sm">
+        <CardHeader>
+          <Tabs defaultValue="explorer">
+            <TabsList class="w-full">
+              <TabsTrigger value="explorer">Explorer</TabsTrigger>
+              <TabsTrigger value="settings">Outline</TabsTrigger>
+            </TabsList>
+          </Tabs>
+        </CardHeader>
+        <CardContent>
+          <div class="flex flex-col gap-1">{fileTree.map((item) => renderItem(item))}</div>
+        </CardContent>
+      </Card>
+    </Example>
+  );
+}
+
+function CollapsibleSettings() {
+  const [isOpen, setIsOpen] = createSignal(false);
+
+  return (
+    <Example title="Settings" class="items-center">
+      <Card class="mx-auto w-full max-w-xs" size="sm">
+        <CardHeader>
+          <CardTitle>Radius</CardTitle>
+          <CardDescription>Set the corner radius of the element.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Collapsible open={isOpen()} onOpenChange={setIsOpen} class="flex items-start gap-2">
+            <FieldGroup class="grid w-full grid-cols-2 gap-2">
+              <Field>
+                <FieldLabel for="radius-x" class="sr-only">
+                  Radius X
+                </FieldLabel>
+                <Input id="radius" placeholder="0" value={0} />
+              </Field>
+              <Field>
+                <FieldLabel for="radius-y" class="sr-only">
+                  Radius Y
+                </FieldLabel>
+                <Input id="radius" placeholder="0" value={0} />
+              </Field>
+              <CollapsibleContent class="col-span-full grid grid-cols-subgrid gap-2">
+                <Field>
+                  <FieldLabel for="radius-x" class="sr-only">
+                    Radius X
+                  </FieldLabel>
+                  <Input id="radius" placeholder="0" value={0} />
+                </Field>
+                <Field>
+                  <FieldLabel for="radius-y" class="sr-only">
+                    Radius Y
+                  </FieldLabel>
+                  <Input id="radius" placeholder="0" value={0} />
+                </Field>
+              </CollapsibleContent>
+            </FieldGroup>
+            <CollapsibleTrigger as={Button} variant="outline" size="icon">
+              <Show when={isOpen()} fallback={<Maximize />}>
+                <Minimize />
+              </Show>
+            </CollapsibleTrigger>
+          </Collapsible>
+        </CardContent>
+      </Card>
+    </Example>
+  );
+}

--- a/tests/collapsible.spec.ts
+++ b/tests/collapsible.spec.ts
@@ -1,0 +1,136 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Collapsible Component", () => {
+  test("examples", async ({ page }) => {
+    await page.goto("/ui/collapsible");
+
+    await page.waitForLoadState("networkidle");
+
+    // ------------------------------------------------------------
+    // File Tree Example
+    // ------------------------------------------------------------
+
+    // 1. Get the file tree section
+    const fileTreeSection = page.getByText("File Tree", { exact: true }).locator("..");
+
+    // 2. Verify the Explorer tab is selected
+    await expect(fileTreeSection.getByRole("tab", { name: "Explorer" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+
+    // 3. Hover over the 'components' folder button
+    await fileTreeSection.getByRole("button", { name: "components" }).hover();
+
+    // 4. Wait for 300ms to simulate user navigation
+    await page.waitForTimeout(300);
+
+    // 5. Click the 'components' folder to expand it
+    await fileTreeSection.getByRole("button", { name: "components" }).click();
+
+    // 6. Verify the collapsible expanded - check for nested content
+    await expect(fileTreeSection.getByRole("button", { name: "ui" })).toBeVisible();
+    await expect(fileTreeSection.getByRole("button", { name: "login-form.tsx" })).toBeVisible();
+    await expect(fileTreeSection.getByRole("button", { name: "register-form.tsx" })).toBeVisible();
+
+    // 7. Hover over the 'ui' folder button
+    await fileTreeSection.getByRole("button", { name: "ui" }).hover();
+
+    // 8. Wait for 300ms to simulate user navigation
+    await page.waitForTimeout(300);
+
+    // 9. Click the 'ui' folder to expand it (nested collapsible)
+    await fileTreeSection.getByRole("button", { name: "ui" }).click();
+
+    // 10. Verify the nested collapsible expanded - check for nested files
+    await expect(fileTreeSection.getByRole("button", { name: "button.tsx" })).toBeVisible();
+    await expect(fileTreeSection.getByRole("button", { name: "card.tsx" })).toBeVisible();
+    await expect(fileTreeSection.getByRole("button", { name: "dialog.tsx" })).toBeVisible();
+
+    // 11. Collapse the 'components' folder
+    await fileTreeSection.getByRole("button", { name: "components" }).click();
+
+    // 12. Verify the content is collapsed - nested items should be hidden
+    await expect(fileTreeSection.getByRole("button", { name: "ui" })).toBeHidden();
+
+    // 13. Expand and test another folder
+    await fileTreeSection.getByRole("button", { name: "lib" }).hover();
+    await page.waitForTimeout(300);
+    await fileTreeSection.getByRole("button", { name: "lib" }).click();
+
+    // 14. Verify lib folder contents
+    await expect(fileTreeSection.getByRole("button", { name: "utils.ts" })).toBeVisible();
+
+    // 15. Collapse the lib folder
+    await fileTreeSection.getByRole("button", { name: "lib" }).click();
+    await expect(fileTreeSection.getByRole("button", { name: "utils.ts" })).toBeHidden();
+
+    // ------------------------------------------------------------
+    // Settings Example
+    // ------------------------------------------------------------
+
+    // 16. Get the settings section
+    const settingsSection = page.getByText("Settings", { exact: true }).locator("..");
+
+    // 17. Verify the card title and description
+    await expect(settingsSection.getByTestId("card-title")).toHaveText("Radius");
+    await expect(settingsSection.getByTestId("card-description")).toHaveText(
+      "Set the corner radius of the element.",
+    );
+
+    // 18. Verify initial state - only 2 input fields visible
+    const initialInputs = settingsSection.getByRole("textbox");
+    await expect(initialInputs).toHaveCount(2);
+
+    // 19. Find and click the expand/maximize button (the icon-only button in the collapsible)
+    const expandButton = settingsSection.getByTestId("collapsible-trigger");
+    await expandButton.hover();
+    await page.waitForTimeout(300);
+    await expandButton.click();
+
+    // 20. Verify expanded state - should now have 4 input fields
+    await expect(settingsSection.getByRole("textbox")).toHaveCount(4);
+
+    // 21. Click again to collapse
+    await expandButton.click();
+
+    // 22. Verify collapsed state - back to 2 input fields
+    await expect(settingsSection.getByRole("textbox")).toHaveCount(2);
+
+    // ------------------------------------------------------------
+    // Docs Page Test - Toggle to Docs and Scroll
+    // ------------------------------------------------------------
+
+    // 23. Click the toggle button to switch to docs view
+    await page.getByRole("button", { name: "Toggle between preview and docs" }).click();
+
+    // 24. Verify the docs page is visible by checking for the main heading
+    await expect(page.getByRole("heading", { name: "Collapsible", level: 1 })).toBeVisible();
+
+    // 25. Verify the Installation section is present
+    await expect(page.getByRole("heading", { name: "Installation", level: 2 })).toBeVisible();
+
+    // 26. Verify the Usage section is present
+    await expect(page.getByRole("heading", { name: "Usage", level: 2 })).toBeVisible();
+
+    // 27. Verify the Examples section is present
+    await expect(page.getByRole("heading", { name: "Examples", level: 2 })).toBeVisible();
+
+    // 28. Verify the File Tree example heading is present
+    await expect(page.getByRole("heading", { name: "File Tree", level: 3 })).toBeVisible();
+
+    // 29. Verify the Settings example heading is present
+    await expect(page.getByRole("heading", { name: "Settings", level: 3 })).toBeVisible();
+
+    // 30. Scroll to bottom to see all examples
+    await page.evaluate(() => {
+      const mainContent = document.querySelector("main");
+      if (mainContent) {
+        mainContent.scrollTo(0, mainContent.scrollHeight);
+      }
+    });
+
+    // 31. Wait for scroll to complete
+    await page.waitForTimeout(500);
+  });
+});


### PR DESCRIPTION
## Summary

- Sync examples from Shadcn UI for collapsible component
- Transform React patterns to SolidJS
- Update/create MDX documentation with Examples section
- Add Playwright test suite for visual validation

## Changes

### Examples (collapsible-example.tsx)
- **File Tree**: Interactive file tree explorer with nested collapsible folders
- **Settings**: Radius settings card with expandable additional fields

### Documentation (collapsible.mdx)
- Installation instructions (CLI and manual)
- Usage examples with import statements
- Full source code for both examples

### Tests (collapsible.spec.ts)
- File tree expand/collapse interactions
- Nested collapsible behavior
- Settings expand/collapse with field count verification
- Docs page validation

## Validation

- [x] Type checking passes
- [x] Playwright visual validation completed
- [x] Playwright test suite passes (1 test)

## Video

[QA Video](https://okesuto.carere.dev/collapsible-qa-video.webm)

## Files Changed

- `src/registry/examples/collapsible-example.tsx` - Component examples
- `src/pages/ui/collapsible.mdx` - Documentation
- `tests/collapsible.spec.ts` - Playwright tests