### PR TITLE
feat(docs): sync dialog examples and documentation

### DIFF
--- a/src/pages/ui/dialog.mdx
+++ b/src/pages/ui/dialog.mdx
@@ -52,6 +52,142 @@ import {
 </Dialog>
 ```
 
+## Examples
+
+Here are the source code of all the examples from the preview page:
+
+### With Form
+
+```tsx
+import { Button } from "~/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "~/components/ui/dialog";
+import { Field, FieldGroup, FieldLabel } from "~/components/ui/field";
+import { Input } from "~/components/ui/input";
+```
+
+```tsx file=../../registry/examples/dialog-example.tsx#L60-L97
+
+```
+
+### Scrollable Content
+
+```tsx
+import { For } from "solid-js";
+import { Button } from "~/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "~/components/ui/dialog";
+```
+
+```tsx file=../../registry/examples/dialog-example.tsx#L99-L129
+
+```
+
+### With Sticky Footer
+
+```tsx
+import { For } from "solid-js";
+import { Button } from "~/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "~/components/ui/dialog";
+```
+
+```tsx file=../../registry/examples/dialog-example.tsx#L131-L166
+
+```
+
+### No Close Button
+
+```tsx
+import { Button } from "~/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "~/components/ui/dialog";
+```
+
+```tsx file=../../registry/examples/dialog-example.tsx#L168-L191
+
+```
+
+### Chat Settings
+
+```tsx
+import { Info } from "lucide-solid";
+import { createSignal } from "solid-js";
+import { Button } from "~/components/ui/button";
+import { Checkbox } from "~/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "~/components/ui/dialog";
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldGroup,
+  FieldLabel,
+  FieldSeparator,
+  FieldSet,
+  FieldTitle,
+} from "~/components/ui/field";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from "~/components/ui/input-group";
+import { Kbd } from "~/components/ui/kbd";
+import { NativeSelect, NativeSelectOption } from "~/components/ui/native-select";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "~/components/ui/select";
+import { Switch } from "~/components/ui/switch";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "~/components/ui/tabs";
+import { Textarea } from "~/components/ui/textarea";
+import { Tooltip, TooltipContent, TooltipTrigger } from "~/components/ui/tooltip";
+```
+
+```tsx file=../../registry/examples/dialog-example.tsx#L193-L515
+
+```
+
 ## Notes
 
 To use the `Dialog` component from within a `Context Menu` or `Dropdown Menu`, you must encase the `Context Menu` or

--- a/src/registry/examples/dialog-example.tsx
+++ b/src/registry/examples/dialog-example.tsx
@@ -1,6 +1,9 @@
-import { For } from "solid-js";
+/** biome-ignore-all lint/a11y/useValidAnchor: <example file> */
+import { Info } from "lucide-solid";
+import { createSignal, For } from "solid-js";
 import { Example, ExampleWrapper } from "@/components/example";
 import { Button } from "@/registry/ui/button";
+import { Checkbox } from "@/registry/ui/checkbox";
 import {
   Dialog,
   DialogClose,
@@ -11,8 +14,36 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/registry/ui/dialog";
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldGroup,
+  FieldLabel,
+  FieldSeparator,
+  FieldSet,
+  FieldTitle,
+} from "@/registry/ui/field";
 import { Input } from "@/registry/ui/input";
-import { Label } from "@/registry/ui/label";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from "@/registry/ui/input-group";
+import { Kbd } from "@/registry/ui/kbd";
+import { NativeSelect, NativeSelectOption } from "@/registry/ui/native-select";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/registry/ui/select";
+import { Switch } from "@/registry/ui/switch";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/registry/ui/tabs";
+import { Textarea } from "@/registry/ui/textarea";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/registry/ui/tooltip";
 
 export default function DialogExample() {
   return (
@@ -21,7 +52,7 @@ export default function DialogExample() {
       <DialogScrollableContent />
       <DialogWithStickyFooter />
       <DialogNoCloseButton />
-      {/* <DialogChatSettings /> */}
+      <DialogChatSettings />
     </ExampleWrapper>
   );
 }
@@ -42,16 +73,16 @@ function DialogWithForm() {
                 updated immediately.
               </DialogDescription>
             </DialogHeader>
-            <div class="flex flex-col gap-4">
-              <div class="flex flex-col gap-2">
-                <Label for="name-1">Name</Label>
+            <FieldGroup>
+              <Field>
+                <FieldLabel for="name-1">Name</FieldLabel>
                 <Input id="name-1" name="name" value="Pedro Duarte" />
-              </div>
-              <div class="flex flex-col gap-2">
-                <Label for="username-1">Username</Label>
+              </Field>
+              <Field>
+                <FieldLabel for="username-1">Username</FieldLabel>
                 <Input id="username-1" name="username" value="@peduarte" />
-              </div>
-            </div>
+              </Field>
+            </FieldGroup>
             <DialogFooter>
               <DialogClose as={Button} variant="outline">
                 Cancel
@@ -159,288 +190,326 @@ function DialogNoCloseButton() {
   );
 }
 
-// function DialogChatSettings() {
-//   const [tab, setTab] = createSignal("general");
-//   const [theme, setTheme] = createSignal("system");
-//   const [accentColor, setAccentColor] = createSignal("default");
-//   const [spokenLanguage, setSpokenLanguage] = createSignal("en");
-//   const [voice, setVoice] = createSignal("samantha");
+const spokenLanguages = [
+  { label: "Auto", value: "auto" },
+  { label: "English", value: "en" },
+  { label: "Spanish", value: "es" },
+  { label: "French", value: "fr" },
+  { label: "German", value: "de" },
+  { label: "Italian", value: "it" },
+  { label: "Portuguese", value: "pt" },
+  { label: "Russian", value: "ru" },
+  { label: "Chinese", value: "zh" },
+  { label: "Japanese", value: "ja" },
+  { label: "Korean", value: "ko" },
+  { label: "Arabic", value: "ar" },
+  { label: "Hindi", value: "hi" },
+  { label: "Bengali", value: "bn" },
+  { label: "Telugu", value: "te" },
+  { label: "Marathi", value: "mr" },
+  { label: "Kannada", value: "kn" },
+  { label: "Malayalam", value: "ml" },
+];
 
-//   return (
-//     <Example title="Chat Settings" class="items-center justify-center">
-//       <Dialog>
-//         <DialogTrigger as={Button} variant="outline">
-//           Chat Settings
-//         </DialogTrigger>
-//         <DialogContent class="min-w-md">
-//           <DialogHeader>
-//             <DialogTitle>Chat Settings</DialogTitle>
-//             <DialogDescription>
-//               Customize your chat settings: theme, accent color, spoken language, voice,
-//               personality, and custom instructions.
-//             </DialogDescription>
-//           </DialogHeader>
-//           <div class="flex flex-col gap-4">
-//             <NativeSelect
-//               value={tab()}
-//               onChange={(e) => setTab(e.target.value)}
-//               class="w-full md:hidden"
-//             >
-//               <NativeSelectOption value="general">General</NativeSelectOption>
-//               <NativeSelectOption value="notifications">Notifications</NativeSelectOption>
-//               <NativeSelectOption value="personalization">Personalization</NativeSelectOption>
-//               <NativeSelectOption value="security">Security</NativeSelectOption>
-//             </NativeSelect>
-//             <Tabs value={tab} onValueChange={setTab}>
-//               <TabsList class="hidden w-full md:flex">
-//                 <TabsTrigger value="general">General</TabsTrigger>
-//                 <TabsTrigger value="notifications">Notifications</TabsTrigger>
-//                 <TabsTrigger value="personalization">Personalization</TabsTrigger>
-//                 <TabsTrigger value="security">Security</TabsTrigger>
-//               </TabsList>
-//               <div class="style-lyra:min-h-[450px] style-maia:min-h-[550px] style-mira:min-h-[450px] style-nova:min-h-[460px] style-vega:min-h-[550px] style-lyra:rounded-none style-maia:rounded-xl style-mira:rounded-md style-nova:rounded-lg style-vega:rounded-lg border style-lyra:p-4 style-maia:p-6 style-mira:p-4 style-nova:p-4 style-vega:p-6 [&_[data-slot=select-trigger]]:min-w-[125px]">
-//                 <TabsContent value="general">
-//                   <FieldSet>
-//                     <FieldGroup>
-//                       <Field orientation="horizontal">
-//                         <FieldLabel htmlFor="theme">Theme</FieldLabel>
-//                         <Select
-//                           items={themes}
-//                           value={theme}
-//                           onValueChange={(value) => setTheme(value as string)}
-//                         >
-//                           <SelectTrigger id="theme">
-//                             <SelectValue />
-//                           </SelectTrigger>
-//                           <SelectContent align="end">
-//                             <SelectGroup>
-//                               {themes.map((theme) => (
-//                                 <SelectItem key={theme.value} value={theme.value}>
-//                                   {theme.label}
-//                                 </SelectItem>
-//                               ))}
-//                             </SelectGroup>
-//                           </SelectContent>
-//                         </Select>
-//                       </Field>
-//                       <FieldSeparator />
-//                       <Field orientation="horizontal">
-//                         <FieldLabel htmlFor="accent-color">Accent Color</FieldLabel>
-//                         <Select
-//                           items={accents}
-//                           value={accentColor}
-//                           onValueChange={(value) => setAccentColor(value as string)}
-//                         >
-//                           <SelectTrigger id="accent-color">
-//                             <SelectValue />
-//                           </SelectTrigger>
-//                           <SelectContent align="end">
-//                             <SelectGroup>
-//                               {accents.map((accent) => (
-//                                 <SelectItem key={accent.value} value={accent.value}>
-//                                   {accent.label}
-//                                 </SelectItem>
-//                               ))}
-//                             </SelectGroup>
-//                           </SelectContent>
-//                         </Select>
-//                       </Field>
-//                       <FieldSeparator />
-//                       <Field orientation="responsive">
-//                         <FieldContent>
-//                           <FieldLabel htmlFor="spoken-language">Spoken Language</FieldLabel>
-//                           <FieldDescription>
-//                             For best results, select the language you mainly speak. If it&apos;s not
-//                             listed, it may still be supported via auto-detection.
-//                           </FieldDescription>
-//                         </FieldContent>
-//                         <Select
-//                           items={spokenLanguages}
-//                           value={spokenLanguage}
-//                           onValueChange={(value) => setSpokenLanguage(value as string)}
-//                         >
-//                           <SelectTrigger id="spoken-language">
-//                             <SelectValue />
-//                           </SelectTrigger>
-//                           <SelectContent align="end">
-//                             <SelectGroup>
-//                               {spokenLanguages.map((language) => (
-//                                 <SelectItem key={language.value} value={language.value}>
-//                                   {language.label}
-//                                 </SelectItem>
-//                               ))}
-//                             </SelectGroup>
-//                           </SelectContent>
-//                         </Select>
-//                       </Field>
-//                       <FieldSeparator />
-//                       <Field orientation="horizontal">
-//                         <FieldLabel htmlFor="voice">Voice</FieldLabel>
-//                         <Select
-//                           items={voices}
-//                           value={voice}
-//                           onValueChange={(value) => setVoice(value as string)}
-//                         >
-//                           <SelectTrigger id="voice">
-//                             <SelectValue />
-//                           </SelectTrigger>
-//                           <SelectContent align="end">
-//                             <SelectGroup>
-//                               {voices.map((voice) => (
-//                                 <SelectItem key={voice.value} value={voice.value}>
-//                                   {voice.label}
-//                                 </SelectItem>
-//                               ))}
-//                             </SelectGroup>
-//                           </SelectContent>
-//                         </Select>
-//                       </Field>
-//                     </FieldGroup>
-//                   </FieldSet>
-//                 </TabsContent>
-//                 <TabsContent value="notifications">
-//                   <FieldGroup>
-//                     <FieldSet>
-//                       <FieldLabel>Responses</FieldLabel>
-//                       <FieldDescription>
-//                         Get notified when ChatGPT responds to requests that take time, like research
-//                         or image generation.
-//                       </FieldDescription>
-//                       <FieldGroup data-slot="checkbox-group">
-//                         <Field orientation="horizontal">
-//                           <Checkbox id="push" defaultChecked disabled />
-//                           <FieldLabel htmlFor="push" class="font-normal">
-//                             Push notifications
-//                           </FieldLabel>
-//                         </Field>
-//                       </FieldGroup>
-//                     </FieldSet>
-//                     <FieldSeparator />
-//                     <FieldSet>
-//                       <FieldLabel>Tasks</FieldLabel>
-//                       <FieldDescription>
-//                         Get notified when tasks you&apos;ve created have updates.{" "}
-//                         <a href="#">Manage tasks</a>
-//                       </FieldDescription>
-//                       <FieldGroup data-slot="checkbox-group">
-//                         <Field orientation="horizontal">
-//                           <Checkbox id="push-tasks" />
-//                           <FieldLabel htmlFor="push-tasks" class="font-normal">
-//                             Push notifications
-//                           </FieldLabel>
-//                         </Field>
-//                         <Field orientation="horizontal">
-//                           <Checkbox id="email-tasks" />
-//                           <FieldLabel htmlFor="email-tasks" class="font-normal">
-//                             Email notifications
-//                           </FieldLabel>
-//                         </Field>
-//                       </FieldGroup>
-//                     </FieldSet>
-//                   </FieldGroup>
-//                 </TabsContent>
-//                 <TabsContent value="personalization">
-//                   <FieldGroup>
-//                     <Field orientation="responsive">
-//                       <FieldLabel htmlFor="nickname">Nickname</FieldLabel>
-//                       <InputGroup>
-//                         <InputGroupInput
-//                           id="nickname"
-//                           placeholder="Broski"
-//                           class="@md/field-group:max-w-[200px]"
-//                         />
-//                         <InputGroupAddon align="inline-end">
-//                           <Tooltip>
-//                             <TooltipTrigger render={<InputGroupButton size="icon-xs" />}>
-//                               <IconPlaceholder
-//                                 lucide="InfoIcon"
-//                                 tabler="IconInfoCircle"
-//                                 hugeicons="AlertCircleIcon"
-//                                 phosphor="InfoIcon"
-//                               />
-//                             </TooltipTrigger>
-//                             <TooltipContent class="flex items-center gap-2">
-//                               Used to identify you in the chat. <Kbd>N</Kbd>
-//                             </TooltipContent>
-//                           </Tooltip>
-//                         </InputGroupAddon>
-//                       </InputGroup>
-//                     </Field>
-//                     <FieldSeparator />
-//                     <Field
-//                       orientation="responsive"
-//                       class="@2xl/field-group:flex-row @md/field-group:flex-col"
-//                     >
-//                       <FieldContent>
-//                         <FieldLabel htmlFor="about">More about you</FieldLabel>
-//                         <FieldDescription>
-//                           Tell us more about yourself. This will be used to help us personalize your
-//                           experience.
-//                         </FieldDescription>
-//                       </FieldContent>
-//                       <Textarea
-//                         id="about"
-//                         placeholder="I'm a software engineer..."
-//                         class="min-h-[120px] @2xl/field-group:min-w-[300px] @md/field-group:min-w-full"
-//                       />
-//                     </Field>
-//                     <FieldSeparator />
-//                     <FieldLabel>
-//                       <Field orientation="horizontal">
-//                         <FieldContent>
-//                           <FieldLabel htmlFor="customization">Enable customizations</FieldLabel>
-//                           <FieldDescription>
-//                             Enable customizations to make ChatGPT more personalized.
-//                           </FieldDescription>
-//                         </FieldContent>
-//                         <Switch id="customization" defaultChecked />
-//                       </Field>
-//                     </FieldLabel>
-//                   </FieldGroup>
-//                 </TabsContent>
-//                 <TabsContent value="security">
-//                   <FieldGroup>
-//                     <Field orientation="horizontal">
-//                       <FieldContent>
-//                         <FieldLabel htmlFor="2fa">Multi-factor authentication</FieldLabel>
-//                         <FieldDescription>
-//                           Enable multi-factor authentication to secure your account. If you do not
-//                           have a two-factor authentication device, you can use a one-time code sent
-//                           to your email.
-//                         </FieldDescription>
-//                       </FieldContent>
-//                       <Switch id="2fa" />
-//                     </Field>
-//                     <FieldSeparator />
-//                     <Field orientation="horizontal">
-//                       <FieldContent>
-//                         <FieldTitle>Log out</FieldTitle>
-//                         <FieldDescription>Log out of your account on this device.</FieldDescription>
-//                       </FieldContent>
-//                       <Button variant="outline" size="sm">
-//                         Log Out
-//                       </Button>
-//                     </Field>
-//                     <FieldSeparator />
-//                     <Field orientation="horizontal">
-//                       <FieldContent>
-//                         <FieldTitle>Log out of all devices</FieldTitle>
-//                         <FieldDescription>
-//                           This will log you out of all devices, including the current session. It
-//                           may take up to 30 minutes for the changes to take effect.
-//                         </FieldDescription>
-//                       </FieldContent>
-//                       <Button variant="outline" size="sm">
-//                         Log Out All
-//                       </Button>
-//                     </Field>
-//                   </FieldGroup>
-//                 </TabsContent>
-//               </div>
-//             </Tabs>
-//           </div>
-//         </DialogContent>
-//       </Dialog>
-//     </Example>
-//   );
-// }
+const voices = [
+  { label: "Samantha", value: "samantha" },
+  { label: "Alex", value: "alex" },
+  { label: "Fred", value: "fred" },
+  { label: "Victoria", value: "victoria" },
+  { label: "Tom", value: "tom" },
+  { label: "Karen", value: "karen" },
+  { label: "Sam", value: "sam" },
+  { label: "Daniel", value: "daniel" },
+];
+
+const themes = [
+  { label: "Light", value: "light" },
+  { label: "Dark", value: "dark" },
+  { label: "System", value: "system" },
+];
+
+const accents = [
+  { label: "Default", value: "default" },
+  { label: "Red", value: "red" },
+  { label: "Blue", value: "blue" },
+  { label: "Green", value: "green" },
+  { label: "Purple", value: "purple" },
+  { label: "Pink", value: "pink" },
+];
+
+function DialogChatSettings() {
+  const [tab, setTab] = createSignal("general");
+  const [theme, setTheme] = createSignal(themes[2]);
+  const [accentColor, setAccentColor] = createSignal(accents[0]);
+  const [spokenLanguage, setSpokenLanguage] = createSignal(spokenLanguages[1]);
+  const [voice, setVoice] = createSignal(voices[0]);
+
+  return (
+    <Example title="Chat Settings" class="items-center justify-center">
+      <Dialog>
+        <DialogTrigger as={Button} variant="outline">
+          Chat Settings
+        </DialogTrigger>
+        <DialogContent class="min-w-md">
+          <DialogHeader>
+            <DialogTitle>Chat Settings</DialogTitle>
+            <DialogDescription>
+              Customize your chat settings: theme, accent color, spoken language, voice,
+              personality, and custom instructions.
+            </DialogDescription>
+          </DialogHeader>
+          <div class="flex flex-col gap-4">
+            <NativeSelect
+              value={tab()}
+              onChange={(e) => setTab(e.currentTarget.value)}
+              class="w-full md:hidden"
+            >
+              <NativeSelectOption value="general">General</NativeSelectOption>
+              <NativeSelectOption value="notifications">Notifications</NativeSelectOption>
+              <NativeSelectOption value="personalization">Personalization</NativeSelectOption>
+              <NativeSelectOption value="security">Security</NativeSelectOption>
+            </NativeSelect>
+            <Tabs value={tab()} onChange={setTab}>
+              <TabsList class="hidden w-full md:flex">
+                <TabsTrigger value="general">General</TabsTrigger>
+                <TabsTrigger value="notifications">Notifications</TabsTrigger>
+                <TabsTrigger value="personalization">Personalization</TabsTrigger>
+                <TabsTrigger value="security">Security</TabsTrigger>
+              </TabsList>
+              <div class="min-h-[450px] rounded-lg border p-4 [&_[data-slot=select-trigger]]:min-w-[125px]">
+                <TabsContent value="general">
+                  <FieldSet>
+                    <FieldGroup>
+                      <Field orientation="horizontal">
+                        <FieldLabel for="theme">Theme</FieldLabel>
+                        <Select
+                          options={themes}
+                          optionValue="value"
+                          optionTextValue="label"
+                          value={theme()}
+                          onChange={setTheme}
+                          itemComponent={(props) => (
+                            <SelectItem item={props.item}>{props.item.rawValue.label}</SelectItem>
+                          )}
+                        >
+                          <SelectTrigger id="theme">
+                            <SelectValue<(typeof themes)[number]>>
+                              {(state) => state.selectedOption().label}
+                            </SelectValue>
+                          </SelectTrigger>
+                          <SelectContent />
+                        </Select>
+                      </Field>
+                      <FieldSeparator />
+                      <Field orientation="horizontal">
+                        <FieldLabel for="accent-color">Accent Color</FieldLabel>
+                        <Select
+                          options={accents}
+                          optionValue="value"
+                          optionTextValue="label"
+                          value={accentColor()}
+                          onChange={setAccentColor}
+                          itemComponent={(props) => (
+                            <SelectItem item={props.item}>{props.item.rawValue.label}</SelectItem>
+                          )}
+                        >
+                          <SelectTrigger id="accent-color">
+                            <SelectValue<(typeof accents)[number]>>
+                              {(state) => state.selectedOption().label}
+                            </SelectValue>
+                          </SelectTrigger>
+                          <SelectContent />
+                        </Select>
+                      </Field>
+                      <FieldSeparator />
+                      <Field orientation="responsive">
+                        <FieldContent>
+                          <FieldLabel for="spoken-language">Spoken Language</FieldLabel>
+                          <FieldDescription>
+                            For best results, select the language you mainly speak. If it's not
+                            listed, it may still be supported via auto-detection.
+                          </FieldDescription>
+                        </FieldContent>
+                        <Select
+                          options={spokenLanguages}
+                          optionValue="value"
+                          optionTextValue="label"
+                          value={spokenLanguage()}
+                          onChange={setSpokenLanguage}
+                          itemComponent={(props) => (
+                            <SelectItem item={props.item}>{props.item.rawValue.label}</SelectItem>
+                          )}
+                        >
+                          <SelectTrigger id="spoken-language">
+                            <SelectValue<(typeof spokenLanguages)[number]>>
+                              {(state) => state.selectedOption().label}
+                            </SelectValue>
+                          </SelectTrigger>
+                          <SelectContent />
+                        </Select>
+                      </Field>
+                      <FieldSeparator />
+                      <Field orientation="horizontal">
+                        <FieldLabel for="voice">Voice</FieldLabel>
+                        <Select
+                          options={voices}
+                          optionValue="value"
+                          optionTextValue="label"
+                          value={voice()}
+                          onChange={setVoice}
+                          itemComponent={(props) => (
+                            <SelectItem item={props.item}>{props.item.rawValue.label}</SelectItem>
+                          )}
+                        >
+                          <SelectTrigger id="voice">
+                            <SelectValue<(typeof voices)[number]>>
+                              {(state) => state.selectedOption().label}
+                            </SelectValue>
+                          </SelectTrigger>
+                          <SelectContent />
+                        </Select>
+                      </Field>
+                    </FieldGroup>
+                  </FieldSet>
+                </TabsContent>
+                <TabsContent value="notifications">
+                  <FieldGroup>
+                    <FieldSet>
+                      <FieldLabel>Responses</FieldLabel>
+                      <FieldDescription>
+                        Get notified when ChatGPT responds to requests that take time, like research
+                        or image generation.
+                      </FieldDescription>
+                      <FieldGroup data-slot="checkbox-group">
+                        <Field orientation="horizontal">
+                          <Checkbox id="push" defaultChecked disabled />
+                          <FieldLabel for="push" class="font-normal">
+                            Push notifications
+                          </FieldLabel>
+                        </Field>
+                      </FieldGroup>
+                    </FieldSet>
+                    <FieldSeparator />
+                    <FieldSet>
+                      <FieldLabel>Tasks</FieldLabel>
+                      <FieldDescription>
+                        Get notified when tasks you've created have updates.{" "}
+                        <a href="#">Manage tasks</a>
+                      </FieldDescription>
+                      <FieldGroup data-slot="checkbox-group">
+                        <Field orientation="horizontal">
+                          <Checkbox id="push-tasks" />
+                          <FieldLabel for="push-tasks" class="font-normal">
+                            Push notifications
+                          </FieldLabel>
+                        </Field>
+                        <Field orientation="horizontal">
+                          <Checkbox id="email-tasks" />
+                          <FieldLabel for="email-tasks" class="font-normal">
+                            Email notifications
+                          </FieldLabel>
+                        </Field>
+                      </FieldGroup>
+                    </FieldSet>
+                  </FieldGroup>
+                </TabsContent>
+                <TabsContent value="personalization">
+                  <FieldGroup>
+                    <Field orientation="responsive">
+                      <FieldLabel for="nickname">Nickname</FieldLabel>
+                      <InputGroup>
+                        <InputGroupInput
+                          id="nickname"
+                          placeholder="Broski"
+                          class="@md/field-group:max-w-[200px]"
+                        />
+                        <InputGroupAddon align="inline-end">
+                          <Tooltip>
+                            <TooltipTrigger as={InputGroupButton} size="icon-xs">
+                              <Info />
+                            </TooltipTrigger>
+                            <TooltipContent class="flex items-center gap-2">
+                              Used to identify you in the chat. <Kbd>N</Kbd>
+                            </TooltipContent>
+                          </Tooltip>
+                        </InputGroupAddon>
+                      </InputGroup>
+                    </Field>
+                    <FieldSeparator />
+                    <Field
+                      orientation="responsive"
+                      class="@2xl/field-group:flex-row @md/field-group:flex-col"
+                    >
+                      <FieldContent>
+                        <FieldLabel for="about">More about you</FieldLabel>
+                        <FieldDescription>
+                          Tell us more about yourself. This will be used to help us personalize your
+                          experience.
+                        </FieldDescription>
+                      </FieldContent>
+                      <Textarea
+                        id="about"
+                        placeholder="I'm a software engineer..."
+                        class="min-h-[120px] @2xl/field-group:min-w-[300px] @md/field-group:min-w-full"
+                      />
+                    </Field>
+                    <FieldSeparator />
+                    <FieldLabel>
+                      <Field orientation="horizontal">
+                        <FieldContent>
+                          <FieldLabel for="customization">Enable customizations</FieldLabel>
+                          <FieldDescription>
+                            Enable customizations to make ChatGPT more personalized.
+                          </FieldDescription>
+                        </FieldContent>
+                        <Switch id="customization" defaultChecked />
+                      </Field>
+                    </FieldLabel>
+                  </FieldGroup>
+                </TabsContent>
+                <TabsContent value="security">
+                  <FieldGroup>
+                    <Field orientation="horizontal">
+                      <FieldContent>
+                        <FieldLabel for="2fa">Multi-factor authentication</FieldLabel>
+                        <FieldDescription>
+                          Enable multi-factor authentication to secure your account. If you do not
+                          have a two-factor authentication device, you can use a one-time code sent
+                          to your email.
+                        </FieldDescription>
+                      </FieldContent>
+                      <Switch id="2fa" />
+                    </Field>
+                    <FieldSeparator />
+                    <Field orientation="horizontal">
+                      <FieldContent>
+                        <FieldTitle>Log out</FieldTitle>
+                        <FieldDescription>Log out of your account on this device.</FieldDescription>
+                      </FieldContent>
+                      <Button variant="outline" size="sm">
+                        Log Out
+                      </Button>
+                    </Field>
+                    <FieldSeparator />
+                    <Field orientation="horizontal">
+                      <FieldContent>
+                        <FieldTitle>Log out of all devices</FieldTitle>
+                        <FieldDescription>
+                          This will log you out of all devices, including the current session. It
+                          may take up to 30 minutes for the changes to take effect.
+                        </FieldDescription>
+                      </FieldContent>
+                      <Button variant="outline" size="sm">
+                        Log Out All
+                      </Button>
+                    </Field>
+                  </FieldGroup>
+                </TabsContent>
+              </div>
+            </Tabs>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </Example>
+  );
+}

--- a/tests/dialog.spec.ts
+++ b/tests/dialog.spec.ts
@@ -1,0 +1,243 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("", () => {
+  test("examples", async ({ page }) => {
+    await page.goto("http://localhost:5181/ui/dialog");
+
+    await page.waitForLoadState("networkidle");
+
+    // ------------------------------------------------------------
+    // With Form Example
+    // ------------------------------------------------------------
+
+    // 1. Get the with form section
+    const withFormSection = page.getByText("With Form", { exact: true }).locator("..");
+
+    // 2. Hover over the 'Edit Profile' button
+    await withFormSection.getByRole("button", { name: "Edit Profile", exact: true }).hover();
+
+    // 3. Wait for 300ms to simulate user navigation
+    await page.waitForTimeout(300);
+
+    // 4. Click the 'Edit Profile' button
+    await withFormSection.getByRole("button", { name: "Edit Profile", exact: true }).click();
+
+    // 5. Verify the dialog is visible
+    const editProfileDialog = page.getByRole("dialog");
+    await expect(editProfileDialog).toBeVisible();
+
+    // 6. Verify the dialog title
+    await expect(editProfileDialog.getByRole("heading", { name: "Edit profile" })).toBeVisible();
+
+    // 7. Verify the name input is present with default value
+    await expect(
+      editProfileDialog.getByRole("textbox", { name: "Name", exact: true }),
+    ).toBeVisible();
+
+    // 8. Verify the username input is present
+    await expect(editProfileDialog.getByRole("textbox", { name: "Username" })).toBeVisible();
+
+    // 9. Verify the Cancel button is visible (DialogClose has accessible name "Dismiss")
+    await expect(editProfileDialog.getByText("Cancel")).toBeVisible();
+
+    // 10. Verify the Save changes button is visible
+    await expect(editProfileDialog.getByRole("button", { name: "Save changes" })).toBeVisible();
+
+    // 11. Click the Cancel button to close the dialog
+    await editProfileDialog.getByText("Cancel").click();
+
+    // 12. Verify the dialog is hidden
+    await expect(editProfileDialog).toBeHidden();
+
+    // ------------------------------------------------------------
+    // Scrollable Content Example
+    // ------------------------------------------------------------
+
+    // 13. Get the scrollable content section
+    const scrollableSection = page.getByText("Scrollable Content", { exact: true }).locator("..");
+
+    // 14. Hover over the 'Scrollable Content' button
+    await scrollableSection
+      .getByRole("button", { name: "Scrollable Content", exact: true })
+      .hover();
+
+    // 15. Wait for 300ms to simulate user navigation
+    await page.waitForTimeout(300);
+
+    // 16. Click the 'Scrollable Content' button
+    await scrollableSection
+      .getByRole("button", { name: "Scrollable Content", exact: true })
+      .click();
+
+    // 17. Verify the dialog is visible
+    const scrollableDialog = page.getByRole("dialog");
+    await expect(scrollableDialog).toBeVisible();
+
+    // 18. Verify the dialog title
+    await expect(
+      scrollableDialog.getByRole("heading", { name: "Scrollable Content" }),
+    ).toBeVisible();
+
+    // 19. Verify the dialog description is visible
+    await expect(
+      scrollableDialog.getByText("This is a dialog with scrollable content."),
+    ).toBeVisible();
+
+    // 20. Close the dialog with Escape key
+    await page.keyboard.press("Escape");
+
+    // 21. Verify the dialog is hidden
+    await expect(scrollableDialog).toBeHidden();
+
+    // ------------------------------------------------------------
+    // With Sticky Footer Example
+    // ------------------------------------------------------------
+
+    // 22. Get the sticky footer section
+    const stickyFooterSection = page.getByText("With Sticky Footer", { exact: true }).locator("..");
+
+    // 23. Hover over the 'Sticky Footer' button
+    await stickyFooterSection.getByRole("button", { name: "Sticky Footer", exact: true }).hover();
+
+    // 24. Wait for 300ms to simulate user navigation
+    await page.waitForTimeout(300);
+
+    // 25. Click the 'Sticky Footer' button
+    await stickyFooterSection.getByRole("button", { name: "Sticky Footer", exact: true }).click();
+
+    // 26. Verify the dialog is visible
+    const stickyFooterDialog = page.getByRole("dialog");
+    await expect(stickyFooterDialog).toBeVisible();
+
+    // 27. Verify the dialog title
+    await expect(
+      stickyFooterDialog.getByRole("heading", { name: "Scrollable Content" }),
+    ).toBeVisible();
+
+    // 28. Verify the Close button is visible in the footer
+    await expect(
+      stickyFooterDialog.getByTestId("dialog-footer").getByTestId("dialog-close"),
+    ).toBeVisible();
+
+    // 29. Click the Close button
+    await stickyFooterDialog.getByTestId("dialog-footer").getByTestId("dialog-close").click();
+
+    // 30. Verify the dialog is hidden
+    await expect(stickyFooterDialog).toBeHidden();
+
+    // ------------------------------------------------------------
+    // No Close Button Example
+    // ------------------------------------------------------------
+
+    // 31. Get the no close button section
+    const noCloseButtonSection = page.getByText("No Close Button", { exact: true }).locator("..");
+
+    // 32. Hover over the 'No Close Button' button
+    await noCloseButtonSection
+      .getByRole("button", { name: "No Close Button", exact: true })
+      .hover();
+
+    // 33. Wait for 300ms to simulate user navigation
+    await page.waitForTimeout(300);
+
+    // 34. Click the 'No Close Button' button
+    await noCloseButtonSection
+      .getByRole("button", { name: "No Close Button", exact: true })
+      .click();
+
+    // 35. Verify the dialog is visible
+    const noCloseButtonDialog = page.getByRole("dialog");
+    await expect(noCloseButtonDialog).toBeVisible();
+
+    // 36. Verify the dialog title
+    await expect(
+      noCloseButtonDialog.getByRole("heading", { name: "No Close Button" }),
+    ).toBeVisible();
+
+    // 37. Verify the description is visible
+    await expect(
+      noCloseButtonDialog.getByText("This dialog doesn't have a close button in the top-right"),
+    ).toBeVisible();
+
+    // 38. Verify only the footer Close button is visible (no X button - DialogClose uses "Dismiss" name)
+    const dismissButtons = noCloseButtonDialog.getByRole("button", { name: "Dismiss" });
+    await expect(dismissButtons).toHaveCount(1);
+
+    // 39. Click the Close button in footer
+    await noCloseButtonDialog.getByTestId("dialog-footer").getByTestId("dialog-close").click();
+
+    // 40. Verify the dialog is hidden
+    await expect(noCloseButtonDialog).toBeHidden();
+
+    // ------------------------------------------------------------
+    // Chat Settings Example
+    // ------------------------------------------------------------
+
+    // 41. Get the chat settings section
+    const chatSettingsSection = page.getByText("Chat Settings", { exact: true }).locator("..");
+
+    // 42. Hover over the 'Chat Settings' button
+    await chatSettingsSection.getByRole("button", { name: "Chat Settings", exact: true }).hover();
+
+    // 43. Wait for 300ms to simulate user navigation
+    await page.waitForTimeout(300);
+
+    // 44. Click the 'Chat Settings' button
+    await chatSettingsSection.getByRole("button", { name: "Chat Settings", exact: true }).click();
+
+    // 45. Verify the dialog is visible
+    const chatSettingsDialog = page.getByRole("dialog");
+    await expect(chatSettingsDialog).toBeVisible();
+
+    // 46. Verify the dialog title
+    await expect(chatSettingsDialog.getByRole("heading", { name: "Chat Settings" })).toBeVisible();
+
+    // 47. Verify the General tab content is visible (default tab) - check select triggers
+    await expect(chatSettingsDialog.getByRole("button", { name: "System" })).toBeVisible();
+    await expect(chatSettingsDialog.getByRole("button", { name: "Default" })).toBeVisible();
+    await expect(chatSettingsDialog.getByRole("button", { name: "English" })).toBeVisible();
+    await expect(chatSettingsDialog.getByRole("button", { name: "Samantha" })).toBeVisible();
+
+    // 48. Verify the Voice field label is visible
+    await expect(
+      chatSettingsDialog.getByTestId("field-label").filter({ hasText: "Voice" }),
+    ).toBeVisible();
+
+    // 49. Click the X button to close the dialog
+    await chatSettingsDialog.getByRole("button", { name: "Dismiss" }).click();
+
+    // 50. Verify the dialog is hidden
+    await expect(chatSettingsDialog).toBeHidden();
+
+    // ------------------------------------------------------------
+    // Docs Page Test - Toggle to Docs and Verify Content
+    // ------------------------------------------------------------
+
+    // 51. Click the toggle button to switch to docs view
+    await page.getByRole("button", { name: "Toggle between preview and docs" }).click();
+
+    // 52. Wait for the docs content to load
+    await page.waitForTimeout(500);
+
+    // 53. Verify the docs page is visible by checking for the main heading
+    await expect(page.getByRole("heading", { name: "Dialog", level: 1 })).toBeVisible();
+
+    // 54. Verify the Installation section is present
+    await expect(page.getByRole("heading", { name: "Installation", level: 2 })).toBeVisible();
+
+    // 55. Verify the Usage section is present
+    await expect(page.getByRole("heading", { name: "Usage", level: 2 })).toBeVisible();
+
+    // 56. Verify the Examples section is present
+    await expect(page.getByRole("heading", { name: "Examples", level: 2 })).toBeVisible();
+
+    // 57. Verify the With Form example section is present
+    await expect(page.getByRole("heading", { name: "With Form", level: 3 })).toBeVisible();
+
+    // 58. Verify the Chat Settings example section is present
+    await expect(page.getByRole("heading", { name: "Chat Settings", level: 3 })).toBeVisible();
+
+    // 59. Verify the Notes section is present
+    await expect(page.getByRole("heading", { name: "Notes", level: 2 })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

- Sync examples from Shadcn UI for dialog component
- Transform React patterns to SolidJS (className → class, useState → createSignal, etc.)
- Update/create MDX documentation with Examples section
- Add comprehensive Playwright test suite

## Examples Synced

1. **With Form** - Dialog with form fields for editing profile
2. **Scrollable Content** - Dialog with scrollable body content
3. **With Sticky Footer** - Dialog with sticky footer for actions
4. **No Close Button** - Dialog without the X close button
5. **Chat Settings** - Complex dialog with tabs, selects, checkboxes, and switches

## Validation

- [x] Type checking passes
- [x] Playwright visual validation completed
- [x] Playwright test suite passes (5.8s)

## Video

[QA Video](https://okesuto.carere.dev/dialog-qa-video.webm)

## Files Changed

- `src/registry/examples/dialog-example.tsx` - Component examples (5 variants)
- `src/pages/ui/dialog.mdx` - Documentation with Examples section
- `tests/dialog.spec.ts` - Playwright test suite

🤖 Generated with [Claude Code](https://claude.ai/code)