### PR TITLE
feat(docs): sync input-group examples and documentation

### DIFF
--- a/src/pages/ui/input-group.mdx
+++ b/src/pages/ui/input-group.mdx
@@ -49,6 +49,164 @@ import {
 </InputGroup>
 ```
 
+## Examples
+
+Here are the source code of all the examples from the preview page:
+
+### Basic
+
+```tsx
+import { Field, FieldGroup, FieldLabel } from "~/components/ui/field";
+import { Input } from "~/components/ui/input";
+import { InputGroup, InputGroupInput } from "~/components/ui/input-group";
+```
+
+```tsx file=../../registry/examples/input-group-example.tsx#L77-L110
+
+```
+
+### With Addons
+
+```tsx
+import { toast } from "solid-sonner";
+import {
+  Copy,
+  EyeOff,
+  Info,
+  Mic,
+  Radio,
+  Search,
+  Star,
+} from "lucide-solid";
+import { Field, FieldDescription, FieldGroup, FieldLabel } from "~/components/ui/field";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+  InputGroupText,
+} from "~/components/ui/input-group";
+```
+
+```tsx file=../../registry/examples/input-group-example.tsx#L112-L209
+
+```
+
+### With Buttons
+
+```tsx
+import { Copy, Trash } from "lucide-solid";
+import { Field, FieldGroup, FieldLabel } from "~/components/ui/field";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from "~/components/ui/input-group";
+```
+
+```tsx file=../../registry/examples/input-group-example.tsx#L211-L261
+
+```
+
+### With Tooltip, Dropdown, Popover
+
+```tsx
+import { toast } from "solid-sonner";
+import { ChevronDown, Info, Star } from "lucide-solid";
+import { ButtonGroup, ButtonGroupText } from "~/components/ui/button-group";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "~/components/ui/dropdown-menu";
+import { Field, FieldDescription, FieldGroup, FieldLabel } from "~/components/ui/field";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from "~/components/ui/input-group";
+import {
+  Popover,
+  PopoverContent,
+  PopoverDescription,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+} from "~/components/ui/popover";
+import { Tooltip, TooltipContent, TooltipTrigger } from "~/components/ui/tooltip";
+```
+
+```tsx file=../../registry/examples/input-group-example.tsx#L263-L350
+
+```
+
+### With Kbd
+
+```tsx
+import { Check, Info, Search, Sparkles } from "lucide-solid";
+import { Field, FieldDescription, FieldGroup, FieldLabel } from "~/components/ui/field";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+} from "~/components/ui/input-group";
+import { Kbd, KbdGroup } from "~/components/ui/kbd";
+import { Spinner } from "~/components/ui/spinner";
+```
+
+```tsx file=../../registry/examples/input-group-example.tsx#L352-L453
+
+```
+
+### In Card
+
+```tsx
+import { ExternalLink, Mail } from "lucide-solid";
+import { Button } from "~/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "~/components/ui/card";
+import { Field, FieldGroup, FieldLabel } from "~/components/ui/field";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+  InputGroupText,
+  InputGroupTextarea,
+} from "~/components/ui/input-group";
+```
+
+```tsx file=../../registry/examples/input-group-example.tsx#L455-L508
+
+```
+
+### Textarea
+
+```tsx
+import { ArrowUp, Code, Copy, Info, RefreshCw } from "lucide-solid";
+import { Field, FieldDescription, FieldGroup, FieldLabel } from "~/components/ui/field";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupText,
+  InputGroupTextarea,
+} from "~/components/ui/input-group";
+import { Textarea } from "~/components/ui/textarea";
+```
+
+```tsx file=../../registry/examples/input-group-example.tsx#L510-L623
+
+```
+
 ## API Reference
 
 ### InputGroup

--- a/src/registry/examples/input-group-example.tsx
+++ b/src/registry/examples/input-group-example.tsx
@@ -1,6 +1,7 @@
 import {
   ArrowUp,
   Check,
+  ChevronDown,
   Code,
   Copy,
   ExternalLink,
@@ -15,8 +16,11 @@ import {
   Star,
   Trash,
 } from "lucide-solid";
+import { createSignal } from "solid-js";
+import { toast } from "solid-sonner";
 import { Example, ExampleWrapper } from "@/components/example";
 import { Button } from "@/registry/ui/button";
+import { ButtonGroup, ButtonGroupText } from "@/registry/ui/button-group";
 import {
   Card,
   CardContent,
@@ -25,6 +29,12 @@ import {
   CardHeader,
   CardTitle,
 } from "@/registry/ui/card";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/registry/ui/dropdown-menu";
 import { Field, FieldDescription, FieldGroup, FieldLabel } from "@/registry/ui/field";
 import { Input } from "@/registry/ui/input";
 import {
@@ -36,18 +46,27 @@ import {
   InputGroupTextarea,
 } from "@/registry/ui/input-group";
 import { Kbd, KbdGroup } from "@/registry/ui/kbd";
+import {
+  Popover,
+  PopoverContent,
+  PopoverDescription,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+} from "@/registry/ui/popover";
 import { Spinner } from "@/registry/ui/spinner";
 import { Textarea } from "@/registry/ui/textarea";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/registry/ui/tooltip";
 
 export default function InputGroupExample() {
-  // const [country, setCountry] = createSignal("+1");
+  const [country, setCountry] = createSignal("+1");
 
   return (
     <ExampleWrapper class="min-w-0">
       <InputGroupBasic />
       <InputGroupWithAddons />
       <InputGroupWithButtons />
-      {/* <InputGroupWithTooltip country={country()} setCountry={setCountry} /> */}
+      <InputGroupWithTooltip country={country()} setCountry={setCountry} />
       <InputGroupWithKbd />
       <InputGroupInCard />
       <InputGroupTextareaExamples />
@@ -150,7 +169,7 @@ function InputGroupWithAddons() {
             <InputGroupInput id="input-icon-both-10" />
             <InputGroupAddon align="inline-end">
               <Star />
-              <InputGroupButton size="icon-xs" onClick={() => console.log("Copied to clipboard")}>
+              <InputGroupButton size="icon-xs" onClick={() => toast("Copied to clipboard")}>
                 <Copy />
               </InputGroupButton>
             </InputGroupAddon>
@@ -241,103 +260,93 @@ function InputGroupWithButtons() {
   );
 }
 
-// function InputGroupWithTooltip({
-//   country,
-//   setCountry,
-// }: {
-//   country: string;
-//   setCountry: (value: string) => void;
-// }) {
-//   return (
-//     <Example title="With Tooltip, Dropdown, Popover">
-//       <FieldGroup>
-//         <Field>
-//           <FieldLabel for="input-tooltip-20">Tooltip</FieldLabel>
-//           <InputGroup>
-//             <InputGroupInput id="input-tooltip-20" />
-//             <InputGroupAddon align="inline-end">
-//               <Tooltip>
-//                 <TooltipTrigger as={InputGroupButton} class="rounded-full" size="icon-xs">
-//                   <Info />
-//                 </TooltipTrigger>
-//                 <TooltipContent>This is content in a tooltip.</TooltipContent>
-//               </Tooltip>
-//             </InputGroupAddon>
-//           </InputGroup>
-//           <FieldDescription>This is a description of the input group.</FieldDescription>
-//         </Field>
-//         <Field>
-//           <FieldLabel for="input-dropdown-21">Dropdown</FieldLabel>
-//           <InputGroup>
-//             <InputGroupInput id="input-dropdown-21" />
-//             <InputGroupAddon>
-//               <DropdownMenu>
-//                 <DropdownMenuTrigger
-//                   render={<InputGroupButton class="text-muted-foreground tabular-nums" />}
-//                 >
-//                   {country} <ChevronDown />
-//                 </DropdownMenuTrigger>
-//                 <DropdownMenuContent
-//                   align="start"
-//                   class="min-w-16"
-//                   sideOffset={10}
-//                   alignOffset={-8}
-//                 >
-//                   <DropdownMenuItem onClick={() => setCountry("+1")}>+1</DropdownMenuItem>
-//                   <DropdownMenuItem onClick={() => setCountry("+44")}>+44</DropdownMenuItem>
-//                   <DropdownMenuItem onClick={() => setCountry("+46")}>+46</DropdownMenuItem>
-//                 </DropdownMenuContent>
-//               </DropdownMenu>
-//             </InputGroupAddon>
-//           </InputGroup>
-//           <FieldDescription>This is a description of the input group.</FieldDescription>
-//         </Field>
-//         <Field>
-//           <FieldLabel for="input-secure-19">Popover</FieldLabel>
-//           <InputGroup>
-//             <Popover>
-//               <PopoverTrigger render={<InputGroupAddon />} nativeButton={false}>
-//                 <InputGroupButton variant="secondary" size="icon-xs">
-//                   <Info />
-//                 </InputGroupButton>
-//               </PopoverTrigger>
-//               <PopoverContent align="start">
-//                 <PopoverHeader>
-//                   <PopoverTitle>Your connection is not secure.</PopoverTitle>
-//                   <PopoverDescription>
-//                     You should not enter any sensitive information on this site.
-//                   </PopoverDescription>
-//                 </PopoverHeader>
-//               </PopoverContent>
-//             </Popover>
-//             <InputGroupAddon class="pl-1 text-muted-foreground">https://</InputGroupAddon>
-//             <InputGroupInput id="input-secure-19" />
-//             <InputGroupAddon align="inline-end">
-//               <InputGroupButton size="icon-xs" onClick={() => toast("Added to favorites")}>
-//                 <Star />
-//               </InputGroupButton>
-//             </InputGroupAddon>
-//           </InputGroup>
-//           <FieldDescription>This is a description of the input group.</FieldDescription>
-//         </Field>
-//         <Field>
-//           <FieldLabel for="url">Button Group</FieldLabel>
-//           <ButtonGroup>
-//             <ButtonGroupText>https://</ButtonGroupText>
-//             <InputGroup>
-//               <InputGroupInput id="url" />
-//               <InputGroupAddon align="inline-end">
-//                 <Info />
-//               </InputGroupAddon>
-//             </InputGroup>
-//             <ButtonGroupText>.com</ButtonGroupText>
-//           </ButtonGroup>
-//           <FieldDescription>This is a description of the input group.</FieldDescription>
-//         </Field>
-//       </FieldGroup>
-//     </Example>
-//   );
-// }
+function InputGroupWithTooltip(props: { country: string; setCountry: (value: string) => void }) {
+  return (
+    <Example title="With Tooltip, Dropdown, Popover">
+      <FieldGroup>
+        <Field>
+          <FieldLabel for="input-tooltip-20">Tooltip</FieldLabel>
+          <InputGroup>
+            <InputGroupInput id="input-tooltip-20" />
+            <InputGroupAddon align="inline-end">
+              <Tooltip>
+                <TooltipTrigger as={InputGroupButton} class="rounded-full" size="icon-xs">
+                  <Info />
+                </TooltipTrigger>
+                <TooltipContent>This is content in a tooltip.</TooltipContent>
+              </Tooltip>
+            </InputGroupAddon>
+          </InputGroup>
+          <FieldDescription>This is a description of the input group.</FieldDescription>
+        </Field>
+        <Field>
+          <FieldLabel for="input-dropdown-21">Dropdown</FieldLabel>
+          <InputGroup>
+            <InputGroupInput id="input-dropdown-21" />
+            <InputGroupAddon>
+              <DropdownMenu>
+                <DropdownMenuTrigger
+                  as={InputGroupButton}
+                  class="text-muted-foreground tabular-nums"
+                >
+                  {props.country} <ChevronDown />
+                </DropdownMenuTrigger>
+                <DropdownMenuContent class="min-w-16">
+                  <DropdownMenuItem onSelect={() => props.setCountry("+1")}>+1</DropdownMenuItem>
+                  <DropdownMenuItem onSelect={() => props.setCountry("+44")}>+44</DropdownMenuItem>
+                  <DropdownMenuItem onSelect={() => props.setCountry("+46")}>+46</DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </InputGroupAddon>
+          </InputGroup>
+          <FieldDescription>This is a description of the input group.</FieldDescription>
+        </Field>
+        <Field>
+          <FieldLabel for="input-secure-19">Popover</FieldLabel>
+          <InputGroup>
+            <Popover>
+              <PopoverTrigger as={InputGroupAddon}>
+                <InputGroupButton variant="secondary" size="icon-xs">
+                  <Info />
+                </InputGroupButton>
+              </PopoverTrigger>
+              <PopoverContent>
+                <PopoverHeader>
+                  <PopoverTitle>Your connection is not secure.</PopoverTitle>
+                  <PopoverDescription>
+                    You should not enter any sensitive information on this site.
+                  </PopoverDescription>
+                </PopoverHeader>
+              </PopoverContent>
+            </Popover>
+            <InputGroupAddon class="pl-1 text-muted-foreground">https://</InputGroupAddon>
+            <InputGroupInput id="input-secure-19" />
+            <InputGroupAddon align="inline-end">
+              <InputGroupButton size="icon-xs" onClick={() => toast("Added to favorites")}>
+                <Star />
+              </InputGroupButton>
+            </InputGroupAddon>
+          </InputGroup>
+          <FieldDescription>This is a description of the input group.</FieldDescription>
+        </Field>
+        <Field>
+          <FieldLabel for="url">Button Group</FieldLabel>
+          <ButtonGroup>
+            <ButtonGroupText>https://</ButtonGroupText>
+            <InputGroup>
+              <InputGroupInput id="url" />
+              <InputGroupAddon align="inline-end">
+                <Info />
+              </InputGroupAddon>
+            </InputGroup>
+            <ButtonGroupText>.com</ButtonGroupText>
+          </ButtonGroup>
+          <FieldDescription>This is a description of the input group.</FieldDescription>
+        </Field>
+      </FieldGroup>
+    </Example>
+  );
+}
 
 function InputGroupWithKbd() {
   return (
@@ -428,9 +437,7 @@ function InputGroupWithKbd() {
           </Field>
         </FieldGroup>
         <Field data-disabled="true">
-          <FieldLabel for="input-group-29">
-            Loading (&quot;data-disabled=&quot;true&quot;)
-          </FieldLabel>
+          <FieldLabel for="input-group-29">Loading ("data-disabled="true")</FieldLabel>
           <InputGroup>
             <InputGroupInput id="input-group-29" disabled value="shadcn" />
             <InputGroupAddon align="inline-end">
@@ -476,7 +483,7 @@ function InputGroupInCard() {
               </InputGroup>
             </Field>
             <Field>
-              <FieldLabel for="feedback-textarea">Feedback & Comments</FieldLabel>
+              <FieldLabel for="feedback-textarea">Feedback &amp; Comments</FieldLabel>
               <InputGroup>
                 <InputGroupTextarea
                   id="feedback-textarea"

--- a/tests/input-group.spec.ts
+++ b/tests/input-group.spec.ts
@@ -1,0 +1,246 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Input Group Examples", () => {
+  test("examples", async ({ page }) => {
+    await page.goto("http://localhost:5175/ui/input-group");
+
+    await page.waitForLoadState("networkidle");
+
+    // ------------------------------------------------------------
+    // Basic Example
+    // ------------------------------------------------------------
+
+    // 1. Verify the Basic section is visible
+    await expect(page.getByText("Basic", { exact: true })).toBeVisible();
+
+    // 2. Verify the default input is visible
+    await expect(page.locator("#input-default-01")).toBeVisible();
+
+    // 3. Verify the input group input is visible
+    await expect(page.locator("#input-group-02")).toBeVisible();
+
+    // 4. Verify the disabled input is visible and disabled
+    const disabledInput = page.locator("#input-disabled-03");
+    await expect(disabledInput).toBeVisible();
+    await expect(disabledInput).toBeDisabled();
+
+    // 5. Verify the invalid input is visible
+    await expect(page.locator("#input-invalid-04")).toBeVisible();
+
+    // 6. Type in the input group input
+    await page.locator("#input-group-02").fill("Test input");
+
+    // 7. Wait for interaction
+    await page.waitForTimeout(300);
+
+    // ------------------------------------------------------------
+    // With Addons Example
+    // ------------------------------------------------------------
+
+    // 8. Verify the With Addons section is visible
+    await expect(page.getByText("With Addons", { exact: true })).toBeVisible();
+
+    // 9. Verify addon inputs are visible using IDs
+    await expect(page.locator("#input-icon-left-05")).toBeVisible();
+    await expect(page.locator("#input-icon-right-07")).toBeVisible();
+    await expect(page.locator("#input-icon-both-09")).toBeVisible();
+
+    // 10. Verify the "Description" field description is visible
+    await expect(page.getByText("This is a description of the input group.").first()).toBeVisible();
+
+    // 11. Interact with the Multiple Icons input
+    await page.locator("#input-icon-both-10").click();
+    await page.waitForTimeout(300);
+
+    // ------------------------------------------------------------
+    // With Buttons Example
+    // ------------------------------------------------------------
+
+    // 12. Verify the With Buttons section is visible
+    await expect(page.getByText("With Buttons", { exact: true })).toBeVisible();
+
+    // 13. Verify buttons are visible
+    await expect(page.getByRole("button", { name: "Default", exact: true })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Outline", exact: true })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Secondary", exact: true }).first(),
+    ).toBeVisible();
+
+    // 14. Click the "Default" button
+    await page.getByRole("button", { name: "Default", exact: true }).hover();
+    await page.waitForTimeout(300);
+    await page.getByRole("button", { name: "Default", exact: true }).click();
+    await page.waitForTimeout(300);
+
+    // ------------------------------------------------------------
+    // With Tooltip, Dropdown, Popover Example
+    // ------------------------------------------------------------
+
+    // 15. Verify the With Tooltip section is visible
+    await expect(page.getByText("With Tooltip, Dropdown, Popover", { exact: true })).toBeVisible();
+
+    // 16. Verify the Tooltip input is visible
+    await expect(page.locator("#input-tooltip-20")).toBeVisible();
+
+    // 17. Verify the Dropdown input is visible
+    await expect(page.locator("#input-dropdown-21")).toBeVisible();
+
+    // 18. Verify the dropdown trigger shows "+1"
+    const dropdownTrigger = page.getByRole("button", { name: /^\+1/ });
+    await expect(dropdownTrigger).toBeVisible();
+
+    // 19. Click the dropdown trigger to open the dropdown
+    await dropdownTrigger.click();
+
+    // 20. Wait for the dropdown menu to appear and verify menuitem +44 is visible
+    const menuItem44 = page.getByRole("menuitem", { name: "+44" });
+    await expect(menuItem44).toBeVisible({ timeout: 10000 });
+
+    // 21. Click on +44 to change the country
+    await menuItem44.click();
+    await page.waitForTimeout(300);
+
+    // 22. Verify the dropdown now shows "+44"
+    await expect(page.getByRole("button", { name: /^\+44/ })).toBeVisible();
+
+    // 23. Verify the Popover input is visible
+    await expect(page.locator("#input-secure-19")).toBeVisible();
+
+    // 24. Verify the Button Group input is visible
+    await expect(page.locator("#url")).toBeVisible();
+    await expect(page.getByText("https://").first()).toBeVisible();
+    await expect(page.getByText(".com")).toBeVisible();
+
+    // ------------------------------------------------------------
+    // With Kbd Example
+    // ------------------------------------------------------------
+
+    // 25. Verify the With Kbd section is visible
+    await expect(page.getByText("With Kbd", { exact: true })).toBeVisible();
+
+    // 26. Verify the "Input Group with Kbd" input is visible
+    await expect(page.locator("#input-kbd-22")).toBeVisible();
+
+    // 27. Verify the ⌘K shortcut is visible
+    await expect(page.getByText("⌘K").first()).toBeVisible();
+
+    // 28. Verify the Username field shows "shadcn"
+    const usernameInput = page.locator("#input-username-26");
+    await expect(usernameInput).toHaveValue("shadcn");
+
+    // 29. Verify the username availability message
+    await expect(page.getByText("This username is available.")).toBeVisible();
+
+    // 30. Verify the search documentation input with "12 results"
+    await expect(page.getByText("12 results")).toBeVisible();
+
+    // 31. Verify the disabled search input shows "Disabled"
+    await expect(page.locator("#input-search-disabled-28")).toBeDisabled();
+
+    // 32. Verify the Spinner/Loading state
+    const loadingInput = page.locator("#input-group-29");
+    await expect(loadingInput).toBeDisabled();
+    await expect(loadingInput).toHaveValue("shadcn");
+
+    // ------------------------------------------------------------
+    // In Card Example
+    // ------------------------------------------------------------
+
+    // 33. Get the In Card section
+    const inCardSection = page.getByText("In Card", { exact: true }).locator("..");
+
+    // 34. Verify the card title
+    await expect(inCardSection.getByText("Card with Input Group")).toBeVisible();
+
+    // 35. Verify the Email Address input
+    await expect(inCardSection.getByRole("textbox", { name: "Email Address" })).toBeVisible();
+
+    // 36. Verify the Website URL input
+    await expect(inCardSection.getByRole("textbox", { name: "Website URL" })).toBeVisible();
+
+    // 37. Verify the Feedback & Comments textarea
+    await expect(inCardSection.getByRole("textbox", { name: "Feedback & Comments" })).toBeVisible();
+
+    // 38. Verify the Cancel and Submit buttons
+    await expect(inCardSection.getByRole("button", { name: "Cancel" })).toBeVisible();
+    await expect(inCardSection.getByRole("button", { name: "Submit" })).toBeVisible();
+
+    // 39. Fill in the form
+    await inCardSection.getByRole("textbox", { name: "Email Address" }).fill("test@example.com");
+    await page.waitForTimeout(300);
+
+    // ------------------------------------------------------------
+    // Textarea Example
+    // ------------------------------------------------------------
+
+    // 40. Verify the Textarea section header is visible (using the example wrapper)
+    await expect(
+      page.getByTestId("example-wrapper").getByText("Textarea", { exact: true }),
+    ).toBeVisible();
+
+    // 41. Verify the "Default Textarea (No Input Group)" is visible using ID
+    await expect(page.locator("#textarea-header-footer-12")).toBeVisible();
+
+    // 42. Verify the "Input Group" textarea is visible using ID
+    await expect(page.locator("#textarea-header-footer-13")).toBeVisible();
+
+    // 43. Verify the "Invalid" textarea is visible using ID
+    await expect(page.locator("#textarea-header-footer-14")).toBeVisible();
+
+    // 44. Verify the "Disabled" textarea is visible and disabled using ID
+    const disabledTextarea = page.locator("#textarea-header-footer-15");
+    await expect(disabledTextarea).toBeVisible();
+    await expect(disabledTextarea).toBeDisabled();
+
+    // 45. Verify the "Addon (block-start)" label is visible
+    await expect(page.getByText("Ask, Search or Chat...")).toBeVisible();
+
+    // 46. Verify the "Addon (block-end)" with character count
+    await expect(page.getByText("0/280 characters")).toBeVisible();
+
+    // 47. Verify the "Post Comment" button
+    await expect(page.getByRole("button", { name: "Post Comment" })).toBeVisible();
+
+    // 48. Verify the Code Editor section
+    await expect(page.getByText("script.js")).toBeVisible();
+    await expect(page.getByText("Line 1, Column 1")).toBeVisible();
+    await expect(page.getByText("JavaScript")).toBeVisible();
+
+    // 49. Fill in a textarea using ID (Addon block-end textarea)
+    await page.locator("#textarea-comment-31").fill("Hello world");
+    await page.waitForTimeout(300);
+
+    // ------------------------------------------------------------
+    // Docs Page Test - Toggle to Docs and Scroll
+    // ------------------------------------------------------------
+
+    // 50. Click the toggle button to switch to docs view
+    await page.getByRole("button", { name: "Toggle between preview and docs" }).click();
+
+    // 51. Wait for the docs page to load
+    await page.waitForTimeout(500);
+
+    // 52. Verify the docs page is visible by checking for the main heading
+    await expect(page.getByRole("heading", { name: "Input Group", level: 1 })).toBeVisible();
+
+    // 53. Verify the Installation section is present
+    await expect(page.getByRole("heading", { name: "Installation", level: 2 })).toBeVisible();
+
+    // 54. Verify the Usage section is present
+    await expect(page.getByRole("heading", { name: "Usage", level: 2 })).toBeVisible();
+
+    // 55. Verify the Examples section is present
+    await expect(page.getByRole("heading", { name: "Examples", level: 2 })).toBeVisible();
+
+    // 56. Scroll down to see all examples
+    await page.evaluate(() => {
+      document.getElementById("ui-doc")?.scrollTo({ top: 5000, behavior: "smooth" });
+    });
+
+    // 57. Wait for scroll animation
+    await page.waitForTimeout(1000);
+
+    // 58. Verify the API Reference section is visible after scrolling
+    await expect(page.getByRole("heading", { name: "API Reference", level: 2 })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

- Sync examples from Shadcn UI for input-group component
- Transform React patterns to SolidJS
- Update/create MDX documentation with Examples section
- Add Playwright test suite for visual validation

## Validation

- [x] Type checking passes
- [x] Playwright visual validation completed
- [x] Playwright test suite passes

## Video

[QA Video](https://okesuto.carere.dev/input-group-qa-video.webm)

## Files Changed

- `src/registry/examples/input-group-example.tsx` - Component examples
- `src/pages/ui/input-group.mdx` - Documentation
- `tests/input-group.spec.ts` - Playwright test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)