### PR TITLE
feat(docs): sync native-select examples and documentation

### DIFF
--- a/src/pages/ui/native-select.mdx
+++ b/src/pages/ui/native-select.mdx
@@ -1,0 +1,164 @@
+---
+title: Native Select
+slug: native-select
+description: A styled native HTML select element with consistent design system integration.
+---
+
+# Native Select
+
+A styled native HTML select element with consistent design system integration.
+
+## Installation
+
+### CLI
+
+```package-dlx
+shadcn@latest add native-select
+```
+
+### Manual
+
+Copy and paste the following code into your project.
+
+```tsx file=../../registry/ui/native-select.tsx showLineNumbers
+
+```
+
+## Usage
+
+```tsx
+import {
+  NativeSelect,
+  NativeSelectOptGroup,
+  NativeSelectOption,
+} from "~/components/ui/native-select";
+```
+
+```tsx showLineNumbers
+<NativeSelect>
+  <NativeSelectOption value="">Select a fruit</NativeSelectOption>
+  <NativeSelectOption value="apple">Apple</NativeSelectOption>
+  <NativeSelectOption value="banana">Banana</NativeSelectOption>
+  <NativeSelectOption value="blueberry">Blueberry</NativeSelectOption>
+  <NativeSelectOption value="grapes" disabled>
+    Grapes
+  </NativeSelectOption>
+  <NativeSelectOption value="pineapple">Pineapple</NativeSelectOption>
+</NativeSelect>
+```
+
+## Examples
+
+Here are the source code of all the examples from the preview page:
+
+### Basic
+
+```tsx
+import {
+  NativeSelect,
+  NativeSelectOption,
+} from "~/components/ui/native-select";
+```
+
+```tsx file=../../registry/examples/native-select-example.tsx#L22-L37
+
+```
+
+### With Groups
+
+Organize options using `NativeSelectOptGroup` for better categorization.
+
+```tsx
+import {
+  NativeSelect,
+  NativeSelectOptGroup,
+  NativeSelectOption,
+} from "~/components/ui/native-select";
+```
+
+```tsx file=../../registry/examples/native-select-example.tsx#L39-L57
+
+```
+
+### Sizes
+
+The native select supports different sizes for various use cases.
+
+```tsx
+import {
+  NativeSelect,
+  NativeSelectOption,
+} from "~/components/ui/native-select";
+```
+
+```tsx file=../../registry/examples/native-select-example.tsx#L59-L78
+
+```
+
+### With Field
+
+Use with the Field component for proper form labeling and descriptions.
+
+```tsx
+import { Field, FieldDescription, FieldLabel } from "~/components/ui/field";
+import {
+  NativeSelect,
+  NativeSelectOption,
+} from "~/components/ui/native-select";
+```
+
+```tsx file=../../registry/examples/native-select-example.tsx#L80-L96
+
+```
+
+### Disabled
+
+Disable individual options or the entire select component.
+
+```tsx
+import {
+  NativeSelect,
+  NativeSelectOption,
+} from "~/components/ui/native-select";
+```
+
+```tsx file=../../registry/examples/native-select-example.tsx#L98-L109
+
+```
+
+### Invalid
+
+Show validation errors with the `aria-invalid` attribute and error styling.
+
+```tsx
+import {
+  NativeSelect,
+  NativeSelectOption,
+} from "~/components/ui/native-select";
+```
+
+```tsx file=../../registry/examples/native-select-example.tsx#L111-L122
+
+```
+
+## Native Select vs Select
+
+- Use `NativeSelect` when you need native browser behavior, better performance, or mobile-optimized dropdowns.
+- Use `Select` when you need custom styling, animations, or complex interactions.
+
+The `NativeSelect` component provides native HTML select functionality with consistent styling that matches your design system.
+
+## Accessibility
+
+- The component maintains all native HTML select accessibility features.
+- Screen readers can navigate through options using arrow keys.
+- The chevron icon is marked as `aria-hidden="true"` to avoid duplication.
+- Use `aria-label` or `aria-labelledby` for additional context when needed.
+
+```tsx showLineNumbers
+<NativeSelect aria-label="Choose your preferred language">
+  <NativeSelectOption value="en">English</NativeSelectOption>
+  <NativeSelectOption value="es">Spanish</NativeSelectOption>
+  <NativeSelectOption value="fr">French</NativeSelectOption>
+</NativeSelect>
+```

--- a/src/registry/examples/native-select-example.tsx
+++ b/src/registry/examples/native-select-example.tsx
@@ -1,0 +1,122 @@
+import { Example, ExampleWrapper } from "@/components/example";
+import { Field, FieldDescription, FieldLabel } from "@/registry/ui/field";
+import {
+  NativeSelect,
+  NativeSelectOptGroup,
+  NativeSelectOption,
+} from "@/registry/ui/native-select";
+
+export default function NativeSelectExample() {
+  return (
+    <ExampleWrapper>
+      <NativeSelectBasic />
+      <NativeSelectWithGroups />
+      <NativeSelectSizes />
+      <NativeSelectWithField />
+      <NativeSelectDisabled />
+      <NativeSelectInvalid />
+    </ExampleWrapper>
+  );
+}
+
+function NativeSelectBasic() {
+  return (
+    <Example title="Basic">
+      <NativeSelect>
+        <NativeSelectOption value="">Select a fruit</NativeSelectOption>
+        <NativeSelectOption value="apple">Apple</NativeSelectOption>
+        <NativeSelectOption value="banana">Banana</NativeSelectOption>
+        <NativeSelectOption value="blueberry">Blueberry</NativeSelectOption>
+        <NativeSelectOption value="grapes" disabled>
+          Grapes
+        </NativeSelectOption>
+        <NativeSelectOption value="pineapple">Pineapple</NativeSelectOption>
+      </NativeSelect>
+    </Example>
+  );
+}
+
+function NativeSelectWithGroups() {
+  return (
+    <Example title="With Groups">
+      <NativeSelect>
+        <NativeSelectOption value="">Select a food</NativeSelectOption>
+        <NativeSelectOptGroup label="Fruits">
+          <NativeSelectOption value="apple">Apple</NativeSelectOption>
+          <NativeSelectOption value="banana">Banana</NativeSelectOption>
+          <NativeSelectOption value="blueberry">Blueberry</NativeSelectOption>
+        </NativeSelectOptGroup>
+        <NativeSelectOptGroup label="Vegetables">
+          <NativeSelectOption value="carrot">Carrot</NativeSelectOption>
+          <NativeSelectOption value="broccoli">Broccoli</NativeSelectOption>
+          <NativeSelectOption value="spinach">Spinach</NativeSelectOption>
+        </NativeSelectOptGroup>
+      </NativeSelect>
+    </Example>
+  );
+}
+
+function NativeSelectSizes() {
+  return (
+    <Example title="Sizes">
+      <div class="flex flex-col gap-4">
+        <NativeSelect size="sm">
+          <NativeSelectOption value="">Select a fruit</NativeSelectOption>
+          <NativeSelectOption value="apple">Apple</NativeSelectOption>
+          <NativeSelectOption value="banana">Banana</NativeSelectOption>
+          <NativeSelectOption value="blueberry">Blueberry</NativeSelectOption>
+        </NativeSelect>
+        <NativeSelect size="default">
+          <NativeSelectOption value="">Select a fruit</NativeSelectOption>
+          <NativeSelectOption value="apple">Apple</NativeSelectOption>
+          <NativeSelectOption value="banana">Banana</NativeSelectOption>
+          <NativeSelectOption value="blueberry">Blueberry</NativeSelectOption>
+        </NativeSelect>
+      </div>
+    </Example>
+  );
+}
+
+function NativeSelectWithField() {
+  return (
+    <Example title="With Field">
+      <Field>
+        <FieldLabel for="native-select-country">Country</FieldLabel>
+        <NativeSelect id="native-select-country">
+          <NativeSelectOption value="">Select a country</NativeSelectOption>
+          <NativeSelectOption value="us">United States</NativeSelectOption>
+          <NativeSelectOption value="uk">United Kingdom</NativeSelectOption>
+          <NativeSelectOption value="ca">Canada</NativeSelectOption>
+          <NativeSelectOption value="au">Australia</NativeSelectOption>
+        </NativeSelect>
+        <FieldDescription>Select your country of residence.</FieldDescription>
+      </Field>
+    </Example>
+  );
+}
+
+function NativeSelectDisabled() {
+  return (
+    <Example title="Disabled">
+      <NativeSelect disabled>
+        <NativeSelectOption value="">Disabled</NativeSelectOption>
+        <NativeSelectOption value="apple">Apple</NativeSelectOption>
+        <NativeSelectOption value="banana">Banana</NativeSelectOption>
+        <NativeSelectOption value="blueberry">Blueberry</NativeSelectOption>
+      </NativeSelect>
+    </Example>
+  );
+}
+
+function NativeSelectInvalid() {
+  return (
+    <Example title="Invalid">
+      <NativeSelect aria-invalid="true">
+        <NativeSelectOption value="">Error state</NativeSelectOption>
+        <NativeSelectOption value="apple">Apple</NativeSelectOption>
+        <NativeSelectOption value="banana">Banana</NativeSelectOption>
+        <NativeSelectOption value="blueberry">Blueberry</NativeSelectOption>
+      </NativeSelect>
+    </Example>
+  );
+}

--- a/tests/native-select.spec.ts
+++ b/tests/native-select.spec.ts
@@ -1,0 +1,193 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("", () => {
+  test("examples", async ({ page }) => {
+    await page.goto(`http://localhost:${process.env.FRONTEND_PORT}/ui/native-select`);
+    await page.waitForLoadState("networkidle");
+
+    // ------------------------------------------------------------
+    // Basic Example
+    // ------------------------------------------------------------
+
+    // 1. Get the basic section
+    const basicSection = page.getByText("Basic", { exact: true }).locator("..");
+
+    // 2. Verify the basic select is visible
+    const basicSelect = basicSection.getByRole("combobox");
+    await expect(basicSelect).toBeVisible();
+
+    // 3. Verify default placeholder text
+    await expect(basicSelect).toHaveValue("");
+
+    // 4. Hover over the select
+    await basicSelect.hover();
+
+    // 5. Wait for 300ms to simulate user navigation
+    await page.waitForTimeout(300);
+
+    // 6. Select an option
+    await basicSelect.selectOption("apple");
+
+    // 7. Verify the selected value
+    await expect(basicSelect).toHaveValue("apple");
+
+    // 8. Verify disabled option exists (Grapes)
+    const grapesOption = basicSection.locator('option[value="grapes"]');
+    await expect(grapesOption).toBeDisabled();
+
+    // ------------------------------------------------------------
+    // With Groups Example
+    // ------------------------------------------------------------
+
+    // 9. Get the with groups section
+    const groupsSection = page.getByText("With Groups", { exact: true }).locator("..");
+
+    // 10. Verify the select with groups is visible
+    const groupsSelect = groupsSection.getByRole("combobox");
+    await expect(groupsSelect).toBeVisible();
+
+    // 11. Hover over the select
+    await groupsSelect.hover();
+
+    // 12. Wait for 300ms to simulate user navigation
+    await page.waitForTimeout(300);
+
+    // 13. Select a fruit option
+    await groupsSelect.selectOption("banana");
+
+    // 14. Verify the selected value
+    await expect(groupsSelect).toHaveValue("banana");
+
+    // 15. Select a vegetable option
+    await groupsSelect.selectOption("carrot");
+
+    // 16. Verify the selected value changed
+    await expect(groupsSelect).toHaveValue("carrot");
+
+    // ------------------------------------------------------------
+    // Sizes Example
+    // ------------------------------------------------------------
+
+    // 17. Get the sizes section
+    const sizesSection = page.getByText("Sizes", { exact: true }).locator("..");
+
+    // 18. Verify both size variants are visible
+    const sizeSelects = sizesSection.getByRole("combobox");
+    await expect(sizeSelects).toHaveCount(2);
+
+    // 19. Hover over the first (small) select
+    await sizeSelects.first().hover();
+
+    // 20. Wait for 300ms to simulate user navigation
+    await page.waitForTimeout(300);
+
+    // 21. Select an option in the small select
+    await sizeSelects.first().selectOption("apple");
+
+    // 22. Verify the selected value
+    await expect(sizeSelects.first()).toHaveValue("apple");
+
+    // 23. Select an option in the default select
+    await sizeSelects.last().selectOption("blueberry");
+
+    // 24. Verify the selected value
+    await expect(sizeSelects.last()).toHaveValue("blueberry");
+
+    // ------------------------------------------------------------
+    // With Field Example
+    // ------------------------------------------------------------
+
+    // 25. Get the with field section
+    const fieldSection = page.getByText("With Field", { exact: true }).locator("..");
+
+    // 26. Verify the field label is visible
+    await expect(fieldSection.locator('[data-slot="field-label"]')).toBeVisible();
+
+    // 27. Verify the select is visible
+    const fieldSelect = fieldSection.getByRole("combobox", { name: "Country" });
+    await expect(fieldSelect).toBeVisible();
+
+    // 28. Verify the field description is visible
+    await expect(fieldSection.locator('[data-slot="field-description"]')).toBeVisible();
+
+    // 29. Hover over the select
+    await fieldSelect.hover();
+
+    // 30. Wait for 300ms to simulate user navigation
+    await page.waitForTimeout(300);
+
+    // 31. Select a country
+    await fieldSelect.selectOption("ca");
+
+    // 32. Verify the selected value
+    await expect(fieldSelect).toHaveValue("ca");
+
+    // ------------------------------------------------------------
+    // Disabled Example
+    // ------------------------------------------------------------
+
+    // 33. Get the disabled section
+    const disabledSection = page.getByText("Disabled", { exact: true }).locator("..");
+
+    // 34. Verify the disabled select is visible
+    const disabledSelect = disabledSection.getByRole("combobox");
+    await expect(disabledSelect).toBeVisible();
+
+    // 35. Verify the select is disabled
+    await expect(disabledSelect).toBeDisabled();
+
+    // ------------------------------------------------------------
+    // Invalid Example
+    // ------------------------------------------------------------
+
+    // 36. Get the invalid section
+    const invalidSection = page.getByText("Invalid", { exact: true }).locator("..");
+
+    // 37. Verify the invalid select is visible
+    const invalidSelect = invalidSection.getByRole("combobox");
+    await expect(invalidSelect).toBeVisible();
+
+    // 38. Verify the select has aria-invalid attribute
+    await expect(invalidSelect).toHaveAttribute("aria-invalid", "true");
+
+    // 39. Hover over the select
+    await invalidSelect.hover();
+
+    // 40. Wait for 300ms to simulate user navigation
+    await page.waitForTimeout(300);
+
+    // 41. Select an option
+    await invalidSelect.selectOption("banana");
+
+    // 42. Verify the selected value
+    await expect(invalidSelect).toHaveValue("banana");
+
+    // ------------------------------------------------------------
+    // Docs Page Test - Toggle to Docs and Scroll
+    // ------------------------------------------------------------
+
+    // 43. Click the toggle button to switch to docs view
+    await page.getByRole("button", { name: "Toggle between preview and docs" }).click();
+
+    // 44. Verify the docs page is visible by checking for the main heading
+    await expect(page.getByRole("heading", { name: "Native Select", level: 1 })).toBeVisible();
+
+    // 45. Verify the Installation section is present
+    await expect(page.getByRole("heading", { name: "Installation", level: 2 })).toBeVisible();
+
+    // 46. Verify the Usage section is present
+    await expect(page.getByRole("heading", { name: "Usage", level: 2 })).toBeVisible();
+
+    // 47. Verify the Examples section is present
+    await expect(page.getByRole("heading", { name: "Examples", level: 2 })).toBeVisible();
+
+    // 48. Scroll to bottom of the page to see all examples
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+
+    // 49. Wait for scroll to complete
+    await page.waitForTimeout(500);
+
+    // 50. Verify the Accessibility section is visible at the bottom
+    await expect(page.getByRole("heading", { name: "Accessibility", level: 2 })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

- Sync examples from Shadcn UI for native-select component
- Transform React patterns to SolidJS
- Create MDX documentation with Examples section
- Add Playwright test suite for visual validation

## Example Variants

| Example | Description |
|---------|-------------|
| Basic | Standard native select with options |
| With Groups | Grouped options using NativeSelectOptGroup |
| Sizes | Small and default size variants |
| With Field | Integration with Field component for labels |
| Disabled | Disabled select state |
| Invalid | Invalid state with aria-invalid attribute |

## Validation

- [x] Type checking passes
- [x] Playwright visual validation completed
- [x] Playwright test suite passes (1 test, all assertions pass)

## Video

[QA Video](https://okesuto.carere.dev/native-select-qa-video.webm)

## Files Changed

- `src/registry/examples/native-select-example.tsx` - Component examples
- `src/pages/ui/native-select.mdx` - Documentation
- `tests/native-select.spec.ts` - Playwright test suite

🤖 Generated with [Claude Code](https://claude.ai/code)