### PR TITLE
feat(docs): sync label examples and documentation

### DIFF
--- a/src/pages/ui/label.mdx
+++ b/src/pages/ui/label.mdx
@@ -33,3 +33,55 @@ import { Label } from "~/components/ui/label";
 ```tsx showLineNumbers
 <Label for="email">Your email address</Label>
 ```
+
+## Examples
+
+Here are the source code of all the examples from the preview page:
+
+### With Checkbox
+
+```tsx
+import { Checkbox } from "~/components/ui/checkbox";
+import { Field } from "~/components/ui/field";
+import { Label } from "~/components/ui/label";
+```
+
+```tsx file=../../registry/examples/label-example.tsx#L19-L28
+
+```
+
+### With Input
+
+```tsx
+import { Field } from "~/components/ui/field";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
+```
+
+```tsx file=../../registry/examples/label-example.tsx#L30-L39
+
+```
+
+### Disabled
+
+```tsx
+import { Field } from "~/components/ui/field";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
+```
+
+```tsx file=../../registry/examples/label-example.tsx#L41-L50
+
+```
+
+### With Textarea
+
+```tsx
+import { Field } from "~/components/ui/field";
+import { Label } from "~/components/ui/label";
+import { Textarea } from "~/components/ui/textarea";
+```
+
+```tsx file=../../registry/examples/label-example.tsx#L52-L61
+
+```

--- a/src/registry/examples/label-example.tsx
+++ b/src/registry/examples/label-example.tsx
@@ -1,13 +1,14 @@
 import { Example, ExampleWrapper } from "@/components/example";
-import { Field } from "../ui/field";
-import { Input } from "../ui/input";
-import { Label } from "../ui/label";
-import { Textarea } from "../ui/textarea";
+import { Checkbox } from "@/registry/ui/checkbox";
+import { Field } from "@/registry/ui/field";
+import { Input } from "@/registry/ui/input";
+import { Label } from "@/registry/ui/label";
+import { Textarea } from "@/registry/ui/textarea";
 
 export default function LabelExample() {
   return (
     <ExampleWrapper>
-      {/* <LabelWithCheckbox /> */}
+      <LabelWithCheckbox />
       <LabelWithInput />
       <LabelDisabled />
       <LabelWithTextarea />
@@ -15,16 +16,16 @@ export default function LabelExample() {
   );
 }
 
-// function LabelWithCheckbox() {
-//   return (
-//     <Example title="With Checkbox">
-//       <Field orientation="horizontal">
-//         <Checkbox id="label-demo-terms" />
-//         <Label for="label-demo-terms">Accept terms and conditions</Label>
-//       </Field>
-//     </Example>
-//   );
-// }
+function LabelWithCheckbox() {
+  return (
+    <Example title="With Checkbox">
+      <Field orientation="horizontal">
+        <Checkbox id="label-demo-terms" />
+        <Label for="label-demo-terms">Accept terms and conditions</Label>
+      </Field>
+    </Example>
+  );
+}
 
 function LabelWithInput() {
   return (

--- a/tests/label.spec.ts
+++ b/tests/label.spec.ts
@@ -1,0 +1,135 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Label Examples", () => {
+  test("examples", async ({ page }) => {
+    await page.goto("http://localhost:5173/ui/label");
+
+    await page.waitForLoadState("networkidle");
+
+    // ------------------------------------------------------------
+    // With Checkbox Example
+    // ------------------------------------------------------------
+
+    // 1. Get the checkbox section
+    const checkboxSection = page.getByText("With Checkbox", { exact: true }).locator("..");
+
+    // 2. Verify the checkbox label is visible
+    await expect(checkboxSection.getByText("Accept terms and conditions")).toBeVisible();
+
+    // 3. Hover over the label (checkbox has hidden input with overlay)
+    await checkboxSection.getByText("Accept terms and conditions").hover();
+
+    // 4. Wait for 300ms to simulate user navigation
+    await page.waitForTimeout(300);
+
+    // 5. Click the label to check the checkbox
+    await checkboxSection.getByText("Accept terms and conditions").click();
+
+    // 6. Verify the checkbox is checked
+    await expect(checkboxSection.getByRole("checkbox")).toBeChecked();
+
+    // 7. Click the label again to toggle checkbox
+    await checkboxSection.getByText("Accept terms and conditions").click();
+
+    // 8. Verify the checkbox is unchecked
+    await expect(checkboxSection.getByRole("checkbox")).not.toBeChecked();
+
+    // ------------------------------------------------------------
+    // With Input Example
+    // ------------------------------------------------------------
+
+    // 9. Get the input section
+    const inputSection = page.getByText("With Input", { exact: true }).locator("..");
+
+    // 10. Verify the label is visible
+    await expect(inputSection.getByText("Username")).toBeVisible();
+
+    // 11. Hover over the input
+    await inputSection.getByRole("textbox", { name: "Username" }).hover();
+
+    // 12. Wait for 300ms to simulate user navigation
+    await page.waitForTimeout(300);
+
+    // 13. Click the input
+    await inputSection.getByRole("textbox", { name: "Username" }).click();
+
+    // 14. Type in the input
+    await inputSection.getByRole("textbox", { name: "Username" }).fill("testuser");
+
+    // 15. Verify the input value
+    await expect(inputSection.getByRole("textbox", { name: "Username" })).toHaveValue("testuser");
+
+    // ------------------------------------------------------------
+    // Disabled Example
+    // ------------------------------------------------------------
+
+    // 16. Get the disabled section
+    const disabledSection = page.getByText("Disabled", { exact: true }).locator("..");
+
+    // 17. Verify the disabled label is visible (using label role)
+    await expect(disabledSection.locator("label")).toBeVisible();
+
+    // 18. Verify the input is disabled
+    await expect(disabledSection.getByRole("textbox", { name: "Disabled" })).toBeDisabled();
+
+    // ------------------------------------------------------------
+    // With Textarea Example
+    // ------------------------------------------------------------
+
+    // 19. Get the textarea section
+    const textareaSection = page.getByText("With Textarea", { exact: true }).locator("..");
+
+    // 20. Verify the label is visible
+    await expect(textareaSection.getByText("Message")).toBeVisible();
+
+    // 21. Hover over the textarea
+    await textareaSection.getByRole("textbox", { name: "Message" }).hover();
+
+    // 22. Wait for 300ms to simulate user navigation
+    await page.waitForTimeout(300);
+
+    // 23. Click the textarea
+    await textareaSection.getByRole("textbox", { name: "Message" }).click();
+
+    // 24. Type in the textarea
+    await textareaSection
+      .getByRole("textbox", { name: "Message" })
+      .fill("Hello, this is a test message!");
+
+    // 25. Verify the textarea value
+    await expect(textareaSection.getByRole("textbox", { name: "Message" })).toHaveValue(
+      "Hello, this is a test message!",
+    );
+
+    // ------------------------------------------------------------
+    // Docs Page Test - Toggle to Docs and Scroll
+    // ------------------------------------------------------------
+
+    // 26. Click the toggle button to switch to docs view
+    await page.getByRole("button", { name: "Toggle between preview and docs" }).click();
+
+    // 27. Verify the docs page is visible by checking for the main heading
+    await expect(page.getByRole("heading", { name: "Label", level: 1 })).toBeVisible();
+
+    // 28. Verify the Installation section is present
+    await expect(page.getByRole("heading", { name: "Installation", level: 2 })).toBeVisible();
+
+    // 29. Verify the Usage section is present
+    await expect(page.getByRole("heading", { name: "Usage", level: 2 })).toBeVisible();
+
+    // 30. Verify the Examples section is present
+    await expect(page.getByRole("heading", { name: "Examples", level: 2 })).toBeVisible();
+
+    // 31. Verify all example headings are present
+    await expect(page.getByRole("heading", { name: "With Checkbox", level: 3 })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "With Input", level: 3 })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Disabled", level: 3 })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "With Textarea", level: 3 })).toBeVisible();
+
+    // 32. Scroll to the bottom of the page to see all examples
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+
+    // 33. Wait for scroll to complete
+    await page.waitForTimeout(500);
+  });
+});


### PR DESCRIPTION
## Summary

- Sync examples from Shadcn UI for label component
- Transform React patterns to SolidJS
- Update/create MDX documentation with Examples section
- Add Playwright test suite for label examples

## Validation

- [x] Type checking passes
- [x] Playwright visual validation completed
- [x] Playwright test suite passes

## Video

[QA Video](https://okesuto.carere.dev/label-qa-video.webm)

## Files Changed

- `src/registry/examples/label-example.tsx` - Component examples
- `src/pages/ui/label.mdx` - Documentation
- `tests/label.spec.ts` - Playwright test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)