### PR TITLE
feat(docs): sync separator examples and documentation

### DIFF
--- a/src/pages/ui/separator.mdx
+++ b/src/pages/ui/separator.mdx
@@ -1,0 +1,79 @@
+---
+title: Separator
+slug: separator
+description: Visually or semantically separates content.
+---
+
+# Separator
+
+Visually or semantically separates content.
+
+## Installation
+
+### CLI
+
+```package-dlx
+shadcn@latest add separator
+```
+
+### Manual
+
+Copy and paste the following code into your project.
+
+```tsx file=../../registry/ui/separator.tsx showLineNumbers
+
+```
+
+## Usage
+
+```tsx
+import { Separator } from "~/components/ui/separator";
+```
+
+```tsx showLineNumbers
+<Separator />
+```
+
+## Examples
+
+Here are the source code of all the examples from the preview page:
+
+### Horizontal
+
+```tsx
+import { Separator } from "~/components/ui/separator";
+```
+
+```tsx file=../../registry/examples/separator-example.tsx#L15-L30
+
+```
+
+### Vertical
+
+```tsx
+import { Separator } from "~/components/ui/separator";
+```
+
+```tsx file=../../registry/examples/separator-example.tsx#L32-L44
+
+```
+
+### Vertical Menu
+
+```tsx
+import { Separator } from "~/components/ui/separator";
+```
+
+```tsx file=../../registry/examples/separator-example.tsx#L46-L67
+
+```
+
+### In List
+
+```tsx
+import { Separator } from "~/components/ui/separator";
+```
+
+```tsx file=../../registry/examples/separator-example.tsx#L69-L90
+
+```

--- a/src/registry/examples/separator-example.tsx
+++ b/src/registry/examples/separator-example.tsx
@@ -1,0 +1,90 @@
+import { Example, ExampleWrapper } from "@/components/example";
+import { Separator } from "@/registry/ui/separator";
+
+export default function SeparatorExample() {
+  return (
+    <ExampleWrapper>
+      <SeparatorHorizontal />
+      <SeparatorVertical />
+      <SeparatorVerticalMenu />
+      <SeparatorInList />
+    </ExampleWrapper>
+  );
+}
+
+function SeparatorHorizontal() {
+  return (
+    <Example title="Horizontal">
+      <div class="flex flex-col gap-4 style-lyra:text-xs/relaxed text-sm">
+        <div class="flex flex-col gap-1">
+          <div class="font-medium leading-none">shadcn/ui</div>
+          <div class="text-muted-foreground">The Foundation for your Design System</div>
+        </div>
+        <Separator />
+        <div>
+          A set of beautifully designed components that you can customize, extend, and build on.
+        </div>
+      </div>
+    </Example>
+  );
+}
+
+function SeparatorVertical() {
+  return (
+    <Example title="Vertical">
+      <div class="flex h-5 items-center gap-4 style-lyra:text-xs/relaxed text-sm">
+        <div>Blog</div>
+        <Separator orientation="vertical" />
+        <div>Docs</div>
+        <Separator orientation="vertical" />
+        <div>Source</div>
+      </div>
+    </Example>
+  );
+}
+
+function SeparatorVerticalMenu() {
+  return (
+    <Example title="Vertical Menu">
+      <div class="flex items-center gap-2 style-lyra:text-xs/relaxed text-sm md:gap-4">
+        <div class="flex flex-col gap-1">
+          <span class="font-medium">Settings</span>
+          <span class="text-muted-foreground text-xs">Manage preferences</span>
+        </div>
+        <Separator orientation="vertical" />
+        <div class="flex flex-col gap-1">
+          <span class="font-medium">Account</span>
+          <span class="text-muted-foreground text-xs">Profile & security</span>
+        </div>
+        <Separator orientation="vertical" />
+        <div class="flex flex-col gap-1">
+          <span class="font-medium">Help</span>
+          <span class="text-muted-foreground text-xs">Support & docs</span>
+        </div>
+      </div>
+    </Example>
+  );
+}
+
+function SeparatorInList() {
+  return (
+    <Example title="In List">
+      <div class="flex flex-col gap-2 style-lyra:text-xs/relaxed text-sm">
+        <dl class="flex items-center justify-between">
+          <dt>Item 1</dt>
+          <dd class="text-muted-foreground">Value 1</dd>
+        </dl>
+        <Separator />
+        <dl class="flex items-center justify-between">
+          <dt>Item 2</dt>
+          <dd class="text-muted-foreground">Value 2</dd>
+        </dl>
+        <Separator />
+        <dl class="flex items-center justify-between">
+          <dt>Item 3</dt>
+          <dd class="text-muted-foreground">Value 3</dd>
+        </dl>
+      </div>
+    </Example>
+  );
+}

--- a/tests/separator.spec.ts
+++ b/tests/separator.spec.ts
@@ -1,0 +1,140 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Separator Component", () => {
+  test("examples", async ({ page }) => {
+    await page.goto(`http://localhost:${process.env.FRONTEND_PORT || 5181}/ui/separator`);
+
+    await page.waitForLoadState("networkidle");
+
+    // ------------------------------------------------------------
+    // Horizontal Example
+    // ------------------------------------------------------------
+
+    // 1. Get the horizontal section
+    const horizontalSection = page.getByText("Horizontal", { exact: true }).locator("..");
+
+    // 2. Verify the horizontal section is visible
+    await expect(horizontalSection).toBeVisible();
+
+    // 3. Verify the separator content is present
+    await expect(horizontalSection.getByText("shadcn/ui")).toBeVisible();
+    await expect(
+      horizontalSection.getByText("The Foundation for your Design System"),
+    ).toBeVisible();
+
+    // 4. Verify the horizontal separator is present
+    await expect(horizontalSection.locator("[data-slot='separator']").first()).toBeVisible();
+
+    // 5. Wait for visual inspection
+    await page.waitForTimeout(300);
+
+    // ------------------------------------------------------------
+    // Vertical Example
+    // ------------------------------------------------------------
+
+    // 6. Get the vertical section
+    const verticalSection = page.getByText("Vertical", { exact: true }).first().locator("..");
+
+    // 7. Verify the vertical section is visible
+    await expect(verticalSection).toBeVisible();
+
+    // 8. Verify the navigation items are present
+    await expect(verticalSection.getByText("Blog")).toBeVisible();
+    await expect(verticalSection.getByText("Docs")).toBeVisible();
+    await expect(verticalSection.getByText("Source")).toBeVisible();
+
+    // 9. Verify vertical separators are present (orientation=vertical)
+    const verticalSeparators = verticalSection.locator(
+      "[data-slot='separator'][data-orientation='vertical']",
+    );
+    await expect(verticalSeparators.first()).toBeVisible();
+
+    // 10. Wait for visual inspection
+    await page.waitForTimeout(300);
+
+    // ------------------------------------------------------------
+    // Vertical Menu Example
+    // ------------------------------------------------------------
+
+    // 11. Get the vertical menu section
+    const verticalMenuSection = page.getByText("Vertical Menu", { exact: true }).locator("..");
+
+    // 12. Verify the vertical menu section is visible
+    await expect(verticalMenuSection).toBeVisible();
+
+    // 13. Verify menu items are present
+    await expect(verticalMenuSection.getByText("Settings")).toBeVisible();
+    await expect(verticalMenuSection.getByText("Manage preferences")).toBeVisible();
+    await expect(verticalMenuSection.getByText("Account")).toBeVisible();
+    await expect(verticalMenuSection.getByText("Profile & security")).toBeVisible();
+    await expect(verticalMenuSection.getByText("Help")).toBeVisible();
+    await expect(verticalMenuSection.getByText("Support & docs")).toBeVisible();
+
+    // 14. Verify vertical separators are present
+    const menuSeparators = verticalMenuSection.locator(
+      "[data-slot='separator'][data-orientation='vertical']",
+    );
+    await expect(menuSeparators.first()).toBeVisible();
+
+    // 15. Wait for visual inspection
+    await page.waitForTimeout(300);
+
+    // ------------------------------------------------------------
+    // In List Example
+    // ------------------------------------------------------------
+
+    // 16. Get the in list section
+    const inListSection = page.getByText("In List", { exact: true }).locator("..");
+
+    // 17. Verify the in list section is visible
+    await expect(inListSection).toBeVisible();
+
+    // 18. Verify list items are present
+    await expect(inListSection.getByText("Item 1")).toBeVisible();
+    await expect(inListSection.getByText("Value 1")).toBeVisible();
+    await expect(inListSection.getByText("Item 2")).toBeVisible();
+    await expect(inListSection.getByText("Value 2")).toBeVisible();
+    await expect(inListSection.getByText("Item 3")).toBeVisible();
+    await expect(inListSection.getByText("Value 3")).toBeVisible();
+
+    // 19. Verify horizontal separators are present in the list
+    const listSeparators = inListSection.locator(
+      "[data-slot='separator'][data-orientation='horizontal']",
+    );
+    await expect(listSeparators.first()).toBeVisible();
+
+    // 20. Wait for visual inspection
+    await page.waitForTimeout(300);
+
+    // ------------------------------------------------------------
+    // Docs Page Test - Toggle to Docs and Scroll
+    // ------------------------------------------------------------
+
+    // 21. Click the toggle button to switch to docs view
+    await page.getByRole("button", { name: "Toggle between preview and docs" }).click();
+
+    // 22. Wait for docs page to load
+    await page.waitForTimeout(500);
+
+    // 23. Verify the docs page is visible by checking for the main heading
+    await expect(page.getByRole("heading", { name: "Separator", level: 1 })).toBeVisible();
+
+    // 24. Verify the Installation section is present
+    await expect(page.getByRole("heading", { name: "Installation", level: 2 })).toBeVisible();
+
+    // 25. Verify the Usage section is present
+    await expect(page.getByRole("heading", { name: "Usage", level: 2 })).toBeVisible();
+
+    // 26. Verify the Examples section is present
+    await expect(page.getByRole("heading", { name: "Examples", level: 2 })).toBeVisible();
+
+    // 27. Scroll to the bottom of the page to see all examples
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+
+    // 28. Wait for scroll to complete
+    await page.waitForTimeout(500);
+
+    // 29. Verify the In List example section is visible in docs
+    await expect(page.getByRole("heading", { name: "In List", level: 3 })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

- Sync examples from Shadcn UI for separator component
- Transform React patterns to SolidJS
- Update/create MDX documentation with Examples section
- Add Playwright test suite for separator component

## Example Variants

- **Horizontal** - Basic horizontal separator with text content
- **Vertical** - Vertical separators between navigation items (Blog, Docs, Source)
- **Vertical Menu** - Vertical separators in a menu with descriptions
- **In List** - Horizontal separators between list items with terms and definitions

## Validation

- [x] Type checking passes
- [x] Playwright visual validation completed
- [x] Playwright test suite passes

## Video

[QA Video](https://okesuto.carere.dev/separator-qa-video.webm)

## Files Changed

- `src/registry/examples/separator-example.tsx` - Component examples
- `src/pages/ui/separator.mdx` - Documentation
- `tests/separator.spec.ts` - Playwright test suite