### PR TITLE
feat(docs): sync sheet examples and documentation

### DIFF
--- a/src/pages/ui/sheet.mdx
+++ b/src/pages/ui/sheet.mdx
@@ -1,0 +1,145 @@
+---
+title: Sheet
+slug: sheet
+description: Extends the Dialog component to display content that complements the main content of the screen.
+---
+
+# Sheet
+
+Extends the Dialog component to display content that complements the main content of the screen.
+
+## Installation
+
+### CLI
+
+```package-dlx
+shadcn@latest add sheet
+```
+
+### Manual
+
+Install the following dependencies:
+
+```package-install
+@kobalte/core
+```
+
+Copy and paste the following code into your project.
+
+```tsx file=../../registry/ui/sheet.tsx showLineNumbers
+
+```
+
+## Usage
+
+```tsx
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "~/components/ui/sheet";
+```
+
+```tsx showLineNumbers
+<Sheet>
+  <SheetTrigger>Open</SheetTrigger>
+  <SheetContent>
+    <SheetHeader>
+      <SheetTitle>Are you absolutely sure?</SheetTitle>
+      <SheetDescription>
+        This action cannot be undone. This will permanently delete your account
+        and remove your data from our servers.
+      </SheetDescription>
+    </SheetHeader>
+  </SheetContent>
+</Sheet>
+```
+
+## Examples
+
+Here are the source code of all the examples from the preview page:
+
+### With Form
+
+```tsx
+import { Button } from "~/components/ui/button";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "~/components/ui/sheet";
+```
+
+```tsx file=../../registry/examples/sheet-example.tsx#L27-L62
+
+```
+
+### No Close Button
+
+```tsx
+import { Button } from "~/components/ui/button";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "~/components/ui/sheet";
+```
+
+```tsx file=../../registry/examples/sheet-example.tsx#L64-L83
+
+```
+
+### Sides
+
+Use the `side` property to `<SheetContent />` to indicate the edge of the screen where the component will appear. The values can be `top`, `right`, `bottom` or `left`.
+
+```tsx
+import { For, Index } from "solid-js";
+import { Button } from "~/components/ui/button";
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "~/components/ui/sheet";
+```
+
+```tsx file=../../registry/examples/sheet-example.tsx#L85-L135
+
+```
+
+## Size
+
+You can adjust the size of the sheet using CSS classes:
+
+```tsx showLineNumbers {3}
+<Sheet>
+  <SheetTrigger>Open</SheetTrigger>
+  <SheetContent class="w-[400px] sm:w-[540px]">
+    <SheetHeader>
+      <SheetTitle>Are you absolutely sure?</SheetTitle>
+      <SheetDescription>
+        This action cannot be undone. This will permanently delete your account
+        and remove your data from our servers.
+      </SheetDescription>
+    </SheetHeader>
+  </SheetContent>
+</Sheet>
+```

--- a/src/registry/examples/sheet-example.tsx
+++ b/src/registry/examples/sheet-example.tsx
@@ -1,0 +1,135 @@
+import { For, Index } from "solid-js";
+import { Example, ExampleWrapper } from "@/components/example";
+import { Button } from "@/registry/ui/button";
+import { Input } from "@/registry/ui/input";
+import { Label } from "@/registry/ui/label";
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/registry/ui/sheet";
+
+export default function SheetExample() {
+  return (
+    <ExampleWrapper>
+      <SheetWithForm />
+      <SheetNoCloseButton />
+      <SheetWithSides />
+    </ExampleWrapper>
+  );
+}
+
+function SheetWithForm() {
+  return (
+    <Example title="With Form">
+      <Sheet>
+        <SheetTrigger as={Button} variant="outline">
+          Open
+        </SheetTrigger>
+        <SheetContent>
+          <SheetHeader>
+            <SheetTitle>Edit profile</SheetTitle>
+            <SheetDescription>
+              Make changes to your profile here. Click save when you&apos;re done.
+            </SheetDescription>
+          </SheetHeader>
+          <div class="px-4">
+            <div class="flex flex-col gap-4">
+              <div class="flex flex-col gap-2">
+                <Label for="sheet-demo-name">Name</Label>
+                <Input id="sheet-demo-name" value="Pedro Duarte" />
+              </div>
+              <div class="flex flex-col gap-2">
+                <Label for="sheet-demo-username">Username</Label>
+                <Input id="sheet-demo-username" value="@peduarte" />
+              </div>
+            </div>
+          </div>
+          <SheetFooter>
+            <Button type="submit">Save changes</Button>
+            <SheetClose as={Button} variant="outline">
+              Close
+            </SheetClose>
+          </SheetFooter>
+        </SheetContent>
+      </Sheet>
+    </Example>
+  );
+}
+
+function SheetNoCloseButton() {
+  return (
+    <Example title="No Close Button">
+      <Sheet>
+        <SheetTrigger as={Button} variant="outline">
+          No Close Button
+        </SheetTrigger>
+        <SheetContent showCloseButton={false}>
+          <SheetHeader>
+            <SheetTitle>No Close Button</SheetTitle>
+            <SheetDescription>
+              This sheet doesn&apos;t have a close button in the top-right corner. You can only
+              close it using the button below.
+            </SheetDescription>
+          </SheetHeader>
+        </SheetContent>
+      </Sheet>
+    </Example>
+  );
+}
+
+const SHEET_SIDES = ["top", "right", "bottom", "left"] as const;
+
+function SheetWithSides() {
+  return (
+    <Example title="Sides">
+      <div class="flex flex-wrap gap-2">
+        <For each={SHEET_SIDES}>
+          {(side) => (
+            <Sheet>
+              <SheetTrigger as={Button} variant="outline" class="capitalize">
+                {side}
+              </SheetTrigger>
+              <SheetContent
+                side={side}
+                class="data-[side=bottom]:max-h-[50vh] data-[side=top]:max-h-[50vh]"
+              >
+                <SheetHeader>
+                  <SheetTitle>Edit profile</SheetTitle>
+                  <SheetDescription>
+                    Make changes to your profile here. Click save when you&apos;re done.
+                  </SheetDescription>
+                </SheetHeader>
+                <div class="no-scrollbar overflow-y-auto px-4">
+                  <Index each={Array.from({ length: 10 })}>
+                    {() => (
+                      <p class="mb-4 style-lyra:mb-2 leading-normal style-lyra:leading-relaxed">
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod
+                        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+                        quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+                        consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+                        cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
+                        non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+                      </p>
+                    )}
+                  </Index>
+                </div>
+                <SheetFooter>
+                  <Button type="submit">Save changes</Button>
+                  <SheetClose as={Button} variant="outline">
+                    Cancel
+                  </SheetClose>
+                </SheetFooter>
+              </SheetContent>
+            </Sheet>
+          )}
+        </For>
+      </div>
+    </Example>
+  );
+}

--- a/tests/sheet.spec.ts
+++ b/tests/sheet.spec.ts
@@ -1,0 +1,216 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Sheet Component", () => {
+  test("examples", async ({ page }) => {
+    await page.goto("http://localhost:5178/ui/sheet");
+
+    await page.waitForLoadState("networkidle");
+
+    // ------------------------------------------------------------
+    // With Form Example
+    // ------------------------------------------------------------
+
+    // 1. Get the With Form section
+    const withFormSection = page.getByText("With Form", { exact: true }).locator("..");
+
+    // 2. Hover over the 'Open' button
+    await withFormSection.getByRole("button", { name: "Open", exact: true }).hover();
+
+    // 3. Wait for 300ms to simulate user navigation
+    await page.waitForTimeout(300);
+
+    // 4. Click the 'Open' button
+    await withFormSection.getByRole("button", { name: "Open", exact: true }).click();
+
+    // 5. Verify the sheet dialog is visible
+    const sheetDialog = page.getByRole("dialog");
+    await expect(sheetDialog).toBeVisible();
+
+    // 6. Verify the 'Edit profile' title is visible
+    await expect(sheetDialog.getByRole("heading", { name: "Edit profile" })).toBeVisible();
+
+    // 7. Verify the Name input is visible
+    await expect(sheetDialog.locator("#sheet-demo-name")).toBeVisible();
+
+    // 8. Verify the Username input is visible
+    await expect(sheetDialog.locator("#sheet-demo-username")).toBeVisible();
+
+    // 9. Verify the 'Save changes' button is visible
+    await expect(sheetDialog.getByRole("button", { name: "Save changes" })).toBeVisible();
+
+    // 10. Hover over the close button
+    await sheetDialog.getByRole("button", { name: "Dismiss" }).nth(1).hover();
+
+    // 11. Wait for 300ms
+    await page.waitForTimeout(300);
+
+    // 12. Click the close button (X icon)
+    await sheetDialog.getByRole("button", { name: "Dismiss" }).nth(1).click();
+
+    // 13. Verify the sheet dialog is hidden
+    await expect(sheetDialog).toBeHidden();
+
+    // ------------------------------------------------------------
+    // No Close Button Example
+    // ------------------------------------------------------------
+
+    // 14. Get the No Close Button section
+    const noCloseButtonSection = page.getByText("No Close Button", { exact: true }).locator("..");
+
+    // 15. Hover over the 'No Close Button' button
+    await noCloseButtonSection
+      .getByRole("button", { name: "No Close Button", exact: true })
+      .hover();
+
+    // 16. Wait for 300ms
+    await page.waitForTimeout(300);
+
+    // 17. Click the 'No Close Button' button
+    await noCloseButtonSection
+      .getByRole("button", { name: "No Close Button", exact: true })
+      .click();
+
+    // 18. Verify the sheet dialog is visible
+    const noCloseSheet = page.getByRole("dialog");
+    await expect(noCloseSheet).toBeVisible();
+
+    // 19. Verify the title is visible
+    await expect(noCloseSheet.getByRole("heading", { name: "No Close Button" })).toBeVisible();
+
+    // 20. Verify there is no close button (X) - the sheet should only have header content
+    // The description should be visible
+    await expect(noCloseSheet.getByText("This sheet doesn't have a close button")).toBeVisible();
+
+    // 21. Press Escape to close
+    await page.keyboard.press("Escape");
+
+    // 22. Verify the sheet is hidden
+    await expect(noCloseSheet).toBeHidden();
+
+    // ------------------------------------------------------------
+    // Sides Example - Top
+    // ------------------------------------------------------------
+
+    // 23. Get the Sides section
+    const sidesSection = page.getByText("Sides", { exact: true }).locator("..");
+
+    // 24. Hover over the 'top' button
+    await sidesSection.getByRole("button", { name: "top", exact: true }).hover();
+
+    // 25. Wait for 300ms
+    await page.waitForTimeout(300);
+
+    // 26. Click the 'top' button
+    await sidesSection.getByRole("button", { name: "top", exact: true }).click();
+
+    // 27. Verify the sheet dialog is visible
+    const topSheet = page.getByRole("dialog");
+    await expect(topSheet).toBeVisible();
+
+    // 28. Verify the title
+    await expect(topSheet.getByRole("heading", { name: "Edit profile" })).toBeVisible();
+
+    // 29. Click the Cancel button
+    await topSheet.getByRole("button", { name: "Dismiss", exact: true }).first().hover();
+    await page.waitForTimeout(300);
+    await topSheet.getByRole("button", { name: "Dismiss", exact: true }).first().click();
+
+    // 30. Verify the sheet is hidden
+    await expect(topSheet).toBeHidden();
+
+    // ------------------------------------------------------------
+    // Sides Example - Right
+    // ------------------------------------------------------------
+
+    // 31. Hover over the 'right' button
+    await sidesSection.getByRole("button", { name: "right", exact: true }).hover();
+
+    // 32. Wait for 300ms
+    await page.waitForTimeout(300);
+
+    // 33. Click the 'right' button
+    await sidesSection.getByRole("button", { name: "right", exact: true }).click();
+
+    // 34. Verify the sheet dialog is visible
+    const rightSheet = page.getByRole("dialog");
+    await expect(rightSheet).toBeVisible();
+
+    // 35. Press Escape to close
+    await page.keyboard.press("Escape");
+
+    // 36. Verify the sheet is hidden
+    await expect(rightSheet).toBeHidden();
+
+    // ------------------------------------------------------------
+    // Sides Example - Bottom
+    // ------------------------------------------------------------
+
+    // 37. Hover over the 'bottom' button
+    await sidesSection.getByRole("button", { name: "bottom", exact: true }).hover();
+
+    // 38. Wait for 300ms
+    await page.waitForTimeout(300);
+
+    // 39. Click the 'bottom' button
+    await sidesSection.getByRole("button", { name: "bottom", exact: true }).click();
+
+    // 40. Verify the sheet dialog is visible
+    const bottomSheet = page.getByRole("dialog");
+    await expect(bottomSheet).toBeVisible();
+
+    // 41. Press Escape to close
+    await page.keyboard.press("Escape");
+
+    // 42. Verify the sheet is hidden
+    await expect(bottomSheet).toBeHidden();
+
+    // ------------------------------------------------------------
+    // Sides Example - Left
+    // ------------------------------------------------------------
+
+    // 43. Hover over the 'left' button
+    await sidesSection.getByRole("button", { name: "left", exact: true }).hover();
+
+    // 44. Wait for 300ms
+    await page.waitForTimeout(300);
+
+    // 45. Click the 'left' button
+    await sidesSection.getByRole("button", { name: "left", exact: true }).click();
+
+    // 46. Verify the sheet dialog is visible
+    const leftSheet = page.getByRole("dialog");
+    await expect(leftSheet).toBeVisible();
+
+    // 47. Press Escape to close
+    await page.keyboard.press("Escape");
+
+    // 48. Verify the sheet is hidden
+    await expect(leftSheet).toBeHidden();
+
+    // ------------------------------------------------------------
+    // Docs Page Test - Toggle to Docs and Scroll
+    // ------------------------------------------------------------
+
+    // 49. Click the toggle button to switch to docs view
+    await page.getByRole("button", { name: "Toggle between preview and docs" }).click();
+
+    // 50. Verify the docs page is visible by checking for the main heading
+    await expect(page.getByRole("heading", { name: "Sheet", level: 1 })).toBeVisible();
+
+    // 51. Verify the Installation section is present
+    await expect(page.getByRole("heading", { name: "Installation", level: 2 })).toBeVisible();
+
+    // 52. Verify the Usage section is present
+    await expect(page.getByRole("heading", { name: "Usage", level: 2 })).toBeVisible();
+
+    // 53. Verify the Examples section is present
+    await expect(page.getByRole("heading", { name: "Examples", level: 2 })).toBeVisible();
+
+    // 54. Scroll to the bottom of the page
+    await page.keyboard.press("End");
+    await page.waitForTimeout(500);
+
+    // 55. Verify the Size section is present at the bottom
+    await expect(page.getByRole("heading", { name: "Size", level: 2 })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

- Sync examples from Shadcn UI for sheet component
- Transform React patterns to SolidJS
- Update/create MDX documentation with Examples section
- Add Playwright test suite for sheet component

## Changes

### Examples (`src/registry/examples/sheet-example.tsx`)
- **With Form**: Sheet with edit profile form containing Name and Username fields
- **No Close Button**: Sheet without the X close button in the top-right corner
- **Sides**: Demonstrates all four side positions (top, right, bottom, left)

### Documentation (`src/pages/ui/sheet.mdx`)
- Installation instructions (CLI and Manual)
- Usage examples with imports
- Examples section with code snippets from all example variants
- Size customization guide

### Tests (`tests/sheet.spec.ts`)
- Playwright E2E tests for all example interactions
- Docs page verification

## Validation

- [x] Type checking passes
- [x] Playwright visual validation completed
- [x] Playwright test suite passes

## Video

[QA Video](https://okesuto.carere.dev/sheet-qa-video.webm)

## Files Changed

- `src/registry/examples/sheet-example.tsx` - Component examples
- `src/pages/ui/sheet.mdx` - Documentation
- `tests/sheet.spec.ts` - Playwright test suite