### PR TITLE
feat(docs): sync popover examples and documentation

### DIFF
--- a/src/pages/ui/popover.mdx
+++ b/src/pages/ui/popover.mdx
@@ -41,9 +41,14 @@ import {
 </Popover>
 ```
 
-## With Title and Description
+## Examples
+
+Here are the source code of all the examples from the preview page:
+
+### Basic
 
 ```tsx
+import { Button } from "~/components/ui/button";
 import {
   Popover,
   PopoverContent,
@@ -54,53 +59,67 @@ import {
 } from "~/components/ui/popover";
 ```
 
-```tsx showLineNumbers
-<Popover>
-  <PopoverTrigger>Open</PopoverTrigger>
-  <PopoverContent>
-    <PopoverHeader>
-      <PopoverTitle>Dimensions</PopoverTitle>
-      <PopoverDescription>Set the dimensions for the layer.</PopoverDescription>
-    </PopoverHeader>
-    {/* Your content here */}
-  </PopoverContent>
-</Popover>
+```tsx file=../../registry/examples/popover-example.tsx#L33-L49
+
 ```
 
-## Custom Placement
-
-Use the `placement` prop on `PopoverContent` to change the popover position.
-
-```tsx showLineNumbers
-<Popover>
-  <PopoverTrigger>Open</PopoverTrigger>
-  <PopoverContent placement="top">
-    Content appears above the trigger.
-  </PopoverContent>
-</Popover>
-```
-
-Available placements: `top`, `top-start`, `top-end`, `right`, `right-start`, `right-end`, `bottom`, `bottom-start`, `bottom-end`, `left`, `left-start`, `left-end`.
-
-## Custom Anchor
-
-Use the `PopoverAnchor` component to anchor the content to a different element.
+### With Form
 
 ```tsx
+import { Button } from "~/components/ui/button";
+import { Field, FieldGroup, FieldLabel } from "~/components/ui/field";
+import { Input } from "~/components/ui/input";
 import {
   Popover,
-  PopoverAnchor,
+  PopoverContent,
+  PopoverDescription,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+} from "~/components/ui/popover";
+```
+
+```tsx file=../../registry/examples/popover-example.tsx#L51-L81
+
+```
+
+### Alignments
+
+```tsx
+import { Button } from "~/components/ui/button";
+import {
+  Popover,
   PopoverContent,
   PopoverTrigger,
 } from "~/components/ui/popover";
 ```
 
-```tsx showLineNumbers
-<Popover>
-  <PopoverAnchor>
-    <span>Anchor element</span>
-  </PopoverAnchor>
-  <PopoverTrigger>Open</PopoverTrigger>
-  <PopoverContent>Content anchored to the anchor element.</PopoverContent>
-</Popover>
+```tsx file=../../registry/examples/popover-example.tsx#L83-L108
+
+```
+
+### In Dialog
+
+```tsx
+import { Button } from "~/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "~/components/ui/dialog";
+import {
+  Popover,
+  PopoverContent,
+  PopoverDescription,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+} from "~/components/ui/popover";
+```
+
+```tsx file=../../registry/examples/popover-example.tsx#L110-L139
+
 ```

--- a/src/registry/examples/popover-example.tsx
+++ b/src/registry/examples/popover-example.tsx
@@ -1,5 +1,14 @@
 import { Example, ExampleWrapper } from "@/components/example";
 import { Button } from "@/registry/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/registry/ui/dialog";
+import { Field, FieldGroup, FieldLabel } from "@/registry/ui/field";
 import { Input } from "@/registry/ui/input";
 import {
   Popover,
@@ -9,15 +18,6 @@ import {
   PopoverTitle,
   PopoverTrigger,
 } from "@/registry/ui/popover";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "../ui/dialog";
-import { Field, FieldGroup, FieldLabel } from "../ui/field";
 
 export default function PopoverExample() {
   return (

--- a/tests/popover.spec.ts
+++ b/tests/popover.spec.ts
@@ -1,0 +1,203 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Popover", () => {
+  test("examples", async ({ page }) => {
+    await page.goto("http://localhost:5175/ui/popover");
+
+    await page.waitForLoadState("networkidle");
+
+    // ------------------------------------------------------------
+    // Basic Example
+    // ------------------------------------------------------------
+
+    // 1. Get the basic section
+    const basicSection = page.getByText("Basic", { exact: true }).locator("..");
+
+    // 2. Hover over the 'Open Popover' button
+    await basicSection.getByRole("button", { name: "Open Popover", exact: true }).hover();
+
+    // 3. Wait for 300ms to simulate user navigation
+    await page.waitForTimeout(300);
+
+    // 4. Click the 'Open Popover' button
+    await basicSection.getByRole("button", { name: "Open Popover", exact: true }).click();
+
+    // 5. Verify the popover dialog is visible
+    const basicPopover = page.getByRole("dialog").filter({ hasText: "Dimensions" });
+    await expect(basicPopover).toBeVisible();
+
+    // 6. Verify the popover title is visible
+    await expect(basicPopover.getByRole("heading", { name: "Dimensions" })).toBeVisible();
+
+    // 7. Verify the popover description is visible
+    await expect(basicPopover.getByText("Set the dimensions for the layer.")).toBeVisible();
+
+    // 8. Close the popover by pressing Escape
+    await page.keyboard.press("Escape");
+
+    // 9. Verify the popover is hidden
+    await expect(basicPopover).toBeHidden();
+
+    // ------------------------------------------------------------
+    // With Form Example
+    // ------------------------------------------------------------
+
+    // 10. Get the with form section
+    const withFormSection = page.getByText("With Form", { exact: true }).locator("..");
+
+    // 11. Hover over the 'Open Popover' button
+    await withFormSection.getByRole("button", { name: "Open Popover", exact: true }).hover();
+
+    // 12. Wait for 300ms to simulate user navigation
+    await page.waitForTimeout(300);
+
+    // 13. Click the 'Open Popover' button
+    await withFormSection.getByRole("button", { name: "Open Popover", exact: true }).click();
+
+    // 14. Verify the popover dialog is visible
+    const formPopover = page.getByRole("dialog").filter({ hasText: "Width" });
+    await expect(formPopover).toBeVisible();
+
+    // 15. Verify the Width field is visible
+    await expect(formPopover.getByText("Width")).toBeVisible();
+
+    // 16. Verify the Height field is visible
+    await expect(formPopover.getByText("Height")).toBeVisible();
+
+    // 17. Verify the Width input has the correct value
+    await expect(formPopover.getByRole("textbox", { name: "Width" })).toHaveValue("100%");
+
+    // 18. Verify the Height input has the correct value
+    await expect(formPopover.getByRole("textbox", { name: "Height" })).toHaveValue("25px");
+
+    // 19. Close the popover by pressing Escape
+    await page.keyboard.press("Escape");
+
+    // 20. Verify the popover is hidden
+    await expect(formPopover).toBeHidden();
+
+    // ------------------------------------------------------------
+    // Alignments Example
+    // ------------------------------------------------------------
+
+    // 21. Get the alignments section
+    const alignmentsSection = page.getByText("Alignments", { exact: true }).locator("..");
+
+    // 22. Hover over the 'Start' button
+    await alignmentsSection.getByRole("button", { name: "Start", exact: true }).hover();
+
+    // 23. Wait for 300ms to simulate user navigation
+    await page.waitForTimeout(300);
+
+    // 24. Click the 'Start' button
+    await alignmentsSection.getByRole("button", { name: "Start", exact: true }).click();
+
+    // 25. Verify the popover is visible with correct content
+    const startPopover = page.getByRole("dialog").filter({ hasText: "Aligned to start" });
+    await expect(startPopover).toBeVisible();
+
+    // 26. Close the popover
+    await page.keyboard.press("Escape");
+    await expect(startPopover).toBeHidden();
+
+    // 27. Hover over the 'Center' button
+    await alignmentsSection.getByRole("button", { name: "Center", exact: true }).hover();
+
+    // 28. Wait for 300ms to simulate user navigation
+    await page.waitForTimeout(300);
+
+    // 29. Click the 'Center' button
+    await alignmentsSection.getByRole("button", { name: "Center", exact: true }).click();
+
+    // 30. Verify the popover is visible with correct content
+    const centerPopover = page.getByRole("dialog").filter({ hasText: "Aligned to center" });
+    await expect(centerPopover).toBeVisible();
+
+    // 31. Close the popover
+    await page.keyboard.press("Escape");
+    await expect(centerPopover).toBeHidden();
+
+    // 32. Hover over the 'End' button
+    await alignmentsSection.getByRole("button", { name: "End", exact: true }).hover();
+
+    // 33. Wait for 300ms to simulate user navigation
+    await page.waitForTimeout(300);
+
+    // 34. Click the 'End' button
+    await alignmentsSection.getByRole("button", { name: "End", exact: true }).click();
+
+    // 35. Verify the popover is visible with correct content
+    const endPopover = page.getByRole("dialog").filter({ hasText: "Aligned to end" });
+    await expect(endPopover).toBeVisible();
+
+    // 36. Close the popover
+    await page.keyboard.press("Escape");
+    await expect(endPopover).toBeHidden();
+
+    // ------------------------------------------------------------
+    // In Dialog Example
+    // ------------------------------------------------------------
+
+    // 37. Get the in dialog section
+    const inDialogSection = page.getByText("In Dialog", { exact: true }).locator("..");
+
+    // 38. Hover over the 'Open Dialog' button
+    await inDialogSection.getByRole("button", { name: "Open Dialog", exact: true }).hover();
+
+    // 39. Wait for 300ms to simulate user navigation
+    await page.waitForTimeout(300);
+
+    // 40. Click the 'Open Dialog' button
+    await inDialogSection.getByRole("button", { name: "Open Dialog", exact: true }).click();
+
+    // 41. Verify the dialog is visible
+    const dialog = page.getByRole("dialog").filter({ hasText: "Popover Example" });
+    await expect(dialog).toBeVisible();
+
+    // 42. Verify the dialog title
+    await expect(dialog.getByRole("heading", { name: "Popover Example" })).toBeVisible();
+
+    // 43. Verify the dialog description
+    await expect(dialog.getByText("Click the button below to see the popover.")).toBeVisible();
+
+    // 44. Verify the 'Open Popover' button inside the dialog is present
+    await expect(dialog.getByRole("button", { name: "Open Popover", exact: true })).toBeVisible();
+
+    // 45. Close the dialog
+    await page.keyboard.press("Escape");
+
+    // 52. Verify the dialog is hidden
+    await expect(dialog).toBeHidden();
+
+    // ------------------------------------------------------------
+    // Docs Page Test - Toggle to Docs and Scroll
+    // ------------------------------------------------------------
+
+    // 53. Click the toggle button to switch to docs view
+    await page.getByRole("button", { name: "Toggle between preview and docs" }).click();
+
+    // 54. Wait for the docs content to load
+    await page.waitForTimeout(500);
+
+    // 55. Verify the docs page is visible by checking for the main heading
+    await expect(page.getByRole("heading", { name: "Popover", level: 1 })).toBeVisible();
+
+    // 56. Verify the Installation section is present
+    await expect(page.getByRole("heading", { name: "Installation", level: 2 })).toBeVisible();
+
+    // 57. Verify the Usage section is present
+    await expect(page.getByRole("heading", { name: "Usage", level: 2 })).toBeVisible();
+
+    // 58. Verify the Examples section is present
+    await expect(page.getByRole("heading", { name: "Examples", level: 2 })).toBeVisible();
+
+    // 59. Scroll to the bottom of the page to see all examples
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+
+    // 60. Wait for scroll animation
+    await page.waitForTimeout(300);
+
+    // 61. Verify the "In Dialog" example heading is visible
+    await expect(page.getByRole("heading", { name: "In Dialog", level: 3 })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

- Sync examples from Shadcn UI for popover component
- Transform React patterns to SolidJS
- Update/create MDX documentation with Examples section
- Add Playwright test suite for popover component

## Validation

- [x] Type checking passes
- [x] Playwright visual validation completed
- [x] Playwright test suite passes

## Video

[QA Video](https://okesuto.carere.dev/popover-qa-video.webm)

## Files Changed

- `src/registry/examples/popover-example.tsx` - Component examples
- `src/pages/ui/popover.mdx` - Documentation
- `tests/popover.spec.ts` - Playwright test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)