### PR TITLE
feat(docs): sync sidebar examples and documentation

### DIFF
--- a/src/pages/ui/sidebar.mdx
+++ b/src/pages/ui/sidebar.mdx
@@ -1,0 +1,151 @@
+---
+title: Sidebar
+slug: sidebar
+description: A composable, themeable and customizable sidebar component.
+---
+
+# Sidebar
+
+A composable, themeable and customizable sidebar component.
+
+Sidebars are one of the most complex components to build. They are central to any application and often contain a lot of moving parts.
+
+## Installation
+
+### CLI
+
+```package-dlx
+shadcn@latest add sidebar
+```
+
+### Manual
+
+Install the following dependencies:
+
+```package-install
+@kobalte/core class-variance-authority
+```
+
+Copy and paste the following code into your project.
+
+```tsx file=../../registry/ui/sidebar.tsx showLineNumbers
+
+```
+
+Add the following colors to your CSS file:
+
+```css showLineNumbers
+@layer base {
+  :root {
+    --sidebar: oklch(0.985 0 0);
+    --sidebar-foreground: oklch(0.145 0 0);
+    --sidebar-primary: oklch(0.205 0 0);
+    --sidebar-primary-foreground: oklch(0.985 0 0);
+    --sidebar-accent: oklch(0.97 0 0);
+    --sidebar-accent-foreground: oklch(0.205 0 0);
+    --sidebar-border: oklch(0.922 0 0);
+    --sidebar-ring: oklch(0.708 0 0);
+  }
+
+  .dark {
+    --sidebar: oklch(0.205 0 0);
+    --sidebar-foreground: oklch(0.985 0 0);
+    --sidebar-primary: oklch(0.488 0.243 264.376);
+    --sidebar-primary-foreground: oklch(0.985 0 0);
+    --sidebar-accent: oklch(0.269 0 0);
+    --sidebar-accent-foreground: oklch(0.985 0 0);
+    --sidebar-border: oklch(1 0 0 / 10%);
+    --sidebar-ring: oklch(0.439 0 0);
+  }
+}
+```
+
+## Usage
+
+```tsx
+import { SidebarProvider, SidebarTrigger } from "~/components/ui/sidebar";
+import { AppSidebar } from "~/components/app-sidebar";
+```
+
+```tsx showLineNumbers
+<SidebarProvider>
+  <AppSidebar />
+  <main>
+    <SidebarTrigger />
+    {children}
+  </main>
+</SidebarProvider>
+```
+
+```tsx showLineNumbers
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarHeader,
+} from "~/components/ui/sidebar";
+
+export function AppSidebar() {
+  return (
+    <Sidebar>
+      <SidebarHeader />
+      <SidebarContent>
+        <SidebarGroup />
+        <SidebarGroup />
+      </SidebarContent>
+      <SidebarFooter />
+    </Sidebar>
+  );
+}
+```
+
+## Structure
+
+A `Sidebar` component is composed of the following parts:
+
+- `SidebarProvider` - Handles collapsible state.
+- `Sidebar` - The sidebar container.
+- `SidebarHeader` and `SidebarFooter` - Sticky at the top and bottom of the sidebar.
+- `SidebarContent` - Scrollable content.
+- `SidebarGroup` - Section within the `SidebarContent`.
+- `SidebarTrigger` - Trigger for the `Sidebar`.
+
+## Examples
+
+Here are the source code of all the examples from the preview page:
+
+### Basic
+
+```tsx
+import { Check, ChevronsUpDown, Search } from "lucide-solid";
+import { createSignal, For, Show } from "solid-js";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "~/components/ui/dropdown-menu";
+import { Item, ItemActions, ItemContent, ItemDescription, ItemTitle } from "~/components/ui/item";
+import { Label } from "~/components/ui/label";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarInput,
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarProvider,
+  SidebarRail,
+  SidebarTrigger,
+} from "~/components/ui/sidebar";
+```
+
+```tsx file=../../registry/examples/sidebar-example.tsx#L38-L266
+
+```

--- a/src/registry/examples/sidebar-example.tsx
+++ b/src/registry/examples/sidebar-example.tsx
@@ -1,0 +1,266 @@
+/** biome-ignore-all lint/a11y/useValidAnchor: <example file> */
+import { Check, ChevronsUpDown, Search } from "lucide-solid";
+import { createSignal, For, Show } from "solid-js";
+import { Example, ExampleWrapper } from "@/components/example";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/registry/ui/dropdown-menu";
+import { Item, ItemActions, ItemContent, ItemDescription, ItemTitle } from "@/registry/ui/item";
+import { Label } from "@/registry/ui/label";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarInput,
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarProvider,
+  SidebarRail,
+  SidebarTrigger,
+} from "@/registry/ui/sidebar";
+
+export default function SidebarExample() {
+  return (
+    <ExampleWrapper class="lg:grid-cols-1">
+      <Basic />
+    </ExampleWrapper>
+  );
+}
+
+function Basic() {
+  const data = {
+    versions: ["1.0.1", "1.1.0-alpha", "2.0.0-beta1"],
+    navMain: [
+      {
+        title: "Getting Started",
+        url: "#",
+        items: [
+          {
+            title: "Installation",
+            url: "#",
+          },
+          {
+            title: "Project Structure",
+            url: "#",
+          },
+        ],
+      },
+      {
+        title: "Building Your Application",
+        url: "#",
+        items: [
+          {
+            title: "Routing",
+            url: "#",
+          },
+          {
+            title: "Data Fetching",
+            url: "#",
+            isActive: true,
+          },
+          {
+            title: "Rendering",
+            url: "#",
+          },
+          {
+            title: "Caching",
+            url: "#",
+          },
+          {
+            title: "Styling",
+            url: "#",
+          },
+          {
+            title: "Optimizing",
+            url: "#",
+          },
+          {
+            title: "Configuring",
+            url: "#",
+          },
+          {
+            title: "Testing",
+            url: "#",
+          },
+          {
+            title: "Authentication",
+            url: "#",
+          },
+          {
+            title: "Deploying",
+            url: "#",
+          },
+          {
+            title: "Upgrading",
+            url: "#",
+          },
+          {
+            title: "Examples",
+            url: "#",
+          },
+        ],
+      },
+      {
+        title: "API Reference",
+        url: "#",
+        items: [
+          {
+            title: "Components",
+            url: "#",
+          },
+          {
+            title: "File Conventions",
+            url: "#",
+          },
+          {
+            title: "Functions",
+            url: "#",
+          },
+          {
+            title: "next.config.js Options",
+            url: "#",
+          },
+          {
+            title: "CLI",
+            url: "#",
+          },
+          {
+            title: "Edge Runtime",
+            url: "#",
+          },
+        ],
+      },
+      {
+        title: "Architecture",
+        url: "#",
+        items: [
+          {
+            title: "Accessibility",
+            url: "#",
+          },
+          {
+            title: "Fast Refresh",
+            url: "#",
+          },
+          {
+            title: "Next.js Compiler",
+            url: "#",
+          },
+          {
+            title: "Supported Browsers",
+            url: "#",
+          },
+          {
+            title: "Turbopack",
+            url: "#",
+          },
+        ],
+      },
+    ],
+  };
+
+  const [selectedVersion, setSelectedVersion] = createSignal(data.versions[0]);
+
+  return (
+    <Example title="Basic">
+      <SidebarProvider>
+        <Sidebar>
+          <SidebarHeader>
+            <SidebarMenu>
+              <SidebarMenuItem>
+                <DropdownMenu>
+                  <DropdownMenuTrigger
+                    as={SidebarMenuButton}
+                    size="lg"
+                    class="data-open:bg-sidebar-accent data-open:text-sidebar-accent-foreground"
+                  >
+                    <Item class="p-0" size="xs">
+                      <ItemContent>
+                        <ItemTitle class="text-sm">Documentation</ItemTitle>
+                        <ItemDescription>v{selectedVersion()}</ItemDescription>
+                      </ItemContent>
+                      <ItemActions>
+                        <ChevronsUpDown />
+                      </ItemActions>
+                    </Item>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent>
+                    <For each={data.versions}>
+                      {(version) => (
+                        <DropdownMenuItem onSelect={() => setSelectedVersion(version)}>
+                          v{version}{" "}
+                          <Show when={version === selectedVersion()}>
+                            <Check class="ml-auto" />
+                          </Show>
+                        </DropdownMenuItem>
+                      )}
+                    </For>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </SidebarMenuItem>
+            </SidebarMenu>
+            <form>
+              <SidebarGroup class="py-0">
+                <SidebarGroupContent class="relative">
+                  <Label for="search" class="sr-only">
+                    Search
+                  </Label>
+                  <SidebarInput id="search" placeholder="Search the docs..." class="pl-8" />
+                  <Search class="pointer-events-none absolute top-1/2 left-2 size-4 -translate-y-1/2 select-none opacity-50" />
+                </SidebarGroupContent>
+              </SidebarGroup>
+            </form>
+          </SidebarHeader>
+          <SidebarContent>
+            <For each={data.navMain}>
+              {(item) => (
+                <SidebarGroup>
+                  <SidebarGroupLabel>{item.title}</SidebarGroupLabel>
+                  <SidebarGroupContent>
+                    <SidebarMenu>
+                      <For each={item.items}>
+                        {(subItem) => (
+                          <SidebarMenuItem>
+                            <SidebarMenuButton
+                              as="a"
+                              href={subItem.url}
+                              isActive={subItem.isActive}
+                            >
+                              {subItem.title}
+                            </SidebarMenuButton>
+                          </SidebarMenuItem>
+                        )}
+                      </For>
+                    </SidebarMenu>
+                  </SidebarGroupContent>
+                </SidebarGroup>
+              )}
+            </For>
+          </SidebarContent>
+          <SidebarRail />
+        </Sidebar>
+        <SidebarInset>
+          <header class="flex h-16 shrink-0 items-center gap-2 px-4">
+            <SidebarTrigger class="-ml-1" />
+          </header>
+          <div class="flex flex-1 flex-col gap-4 p-4">
+            <div class="grid auto-rows-min gap-4 md:grid-cols-3">
+              <div class="aspect-video rounded-xl bg-muted/50" />
+              <div class="aspect-video rounded-xl bg-muted/50" />
+              <div class="aspect-video rounded-xl bg-muted/50" />
+            </div>
+            <div class="min-h-[100vh] flex-1 rounded-xl bg-muted/50 md:min-h-min" />
+          </div>
+        </SidebarInset>
+      </SidebarProvider>
+    </Example>
+  );
+}

--- a/tests/sidebar.spec.ts
+++ b/tests/sidebar.spec.ts
@@ -1,0 +1,103 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Sidebar", () => {
+  test("examples", async ({ page }) => {
+    // Set mobile viewport to trigger mobile sidebar behavior
+    await page.setViewportSize({ width: 375, height: 667 });
+
+    await page.goto("http://localhost:5183/ui/sidebar");
+
+    await page.waitForLoadState("networkidle");
+
+    // ------------------------------------------------------------
+    // Basic Example - Sidebar Toggle
+    // ------------------------------------------------------------
+
+    // 1. Get the sidebar trigger button (use testId to avoid ambiguity with rail)
+    const sidebarTrigger = page.getByTestId("sidebar-trigger");
+
+    // 2. Hover over the 'Toggle Sidebar' button
+    await sidebarTrigger.hover();
+
+    // 3. Wait for 300ms to simulate user navigation
+    await page.waitForTimeout(300);
+
+    // 4. Click the 'Toggle Sidebar' button
+    await sidebarTrigger.click();
+
+    // 5. Verify the sidebar dialog is visible
+    const sidebarDialog = page.getByRole("dialog", { name: "Sidebar" });
+    await expect(sidebarDialog).toBeVisible();
+
+    // 6. Verify the Documentation button is visible with initial version
+    await expect(
+      sidebarDialog.getByRole("button", { name: /Documentation v1\.0\.1/ }),
+    ).toBeVisible();
+
+    // 7. Verify the search input is visible
+    await expect(sidebarDialog.getByRole("textbox", { name: "Search" })).toBeVisible();
+
+    // 8. Verify navigation sections are visible
+    await expect(sidebarDialog.getByText("Getting Started")).toBeVisible();
+    await expect(sidebarDialog.getByText("Building Your Application")).toBeVisible();
+    await expect(sidebarDialog.getByText("API Reference")).toBeVisible();
+    await expect(sidebarDialog.getByText("Architecture")).toBeVisible();
+
+    // 9. Verify navigation links are visible
+    await expect(sidebarDialog.getByRole("link", { name: "Installation" })).toBeVisible();
+    await expect(sidebarDialog.getByRole("link", { name: "Routing" })).toBeVisible();
+    await expect(sidebarDialog.getByRole("link", { name: "Components" })).toBeVisible();
+
+    // ------------------------------------------------------------
+    // Basic Example - Version Dropdown
+    // ------------------------------------------------------------
+
+    // 10. Click the Documentation dropdown button
+    await sidebarDialog.getByRole("button", { name: /Documentation v1\.0\.1/ }).click();
+
+    // 11. Verify the dropdown menu is visible with all versions
+    const versionMenu = page.getByRole("menu", { name: /Documentation/ });
+    await expect(versionMenu).toBeVisible();
+    await expect(versionMenu.getByRole("menuitem", { name: "v1.0.1" })).toBeVisible();
+    await expect(versionMenu.getByRole("menuitem", { name: "v1.1.0-alpha" })).toBeVisible();
+    await expect(versionMenu.getByRole("menuitem", { name: "v2.0.0-beta1" })).toBeVisible();
+
+    // 12. Wait for 300ms
+    await page.waitForTimeout(300);
+
+    // 13. Select a different version
+    await versionMenu.getByRole("menuitem", { name: "v2.0.0-beta1" }).click();
+
+    // 14. Verify the version changed
+    await expect(
+      sidebarDialog.getByRole("button", { name: /Documentation v2\.0\.0-beta1/ }),
+    ).toBeVisible();
+  });
+
+  test("docs page", async ({ page }) => {
+    await page.goto("http://localhost:5183/ui/sidebar");
+
+    await page.waitForLoadState("networkidle");
+
+    // Click the toggle button to switch to docs view
+    await page.getByRole("button", { name: "Toggle between preview and docs" }).click();
+
+    // Wait for docs to load
+    await page.waitForTimeout(500);
+
+    // Verify the docs page is visible by checking for the main heading
+    await expect(page.getByRole("heading", { name: "Sidebar", level: 1 })).toBeVisible();
+
+    // Verify the Installation section is present
+    await expect(page.getByRole("heading", { name: "Installation", level: 2 })).toBeVisible();
+
+    // Verify the Usage section is present
+    await expect(page.getByRole("heading", { name: "Usage", level: 2 })).toBeVisible();
+
+    // Verify the Structure section is present
+    await expect(page.getByRole("heading", { name: "Structure", level: 2 })).toBeVisible();
+
+    // Verify the Examples section is present
+    await expect(page.getByRole("heading", { name: "Examples", level: 2 })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

- Sync examples from Shadcn UI for sidebar component
- Transform React patterns to SolidJS
- Add/update MDX documentation with Examples section
- Add Playwright test suite for sidebar functionality

## Changes

- `src/registry/examples/sidebar-example.tsx` - Sidebar example with:
  - Navigation sections (Getting Started, Building Your Application, API Reference, Architecture)
  - Version dropdown with selection functionality
  - Search input
  - Mobile responsive sidebar (sheet-based)
  
- `src/pages/ui/sidebar.mdx` - Documentation with:
  - Installation instructions (CLI and Manual)
  - Usage examples
  - Structure documentation
  - Examples section

- `tests/sidebar.spec.ts` - Playwright tests covering:
  - Sidebar toggle functionality
  - Version dropdown interaction
  - Navigation verification
  - Documentation page validation

## Validation

- [x] Type checking passes
- [x] Playwright visual validation completed
- [x] Playwright test suite passes (2 tests)

## Video

[QA Video](https://okesuto.carere.dev/sidebar-qa-video.webm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)