### PR TITLE
feat(docs): sync toggle-group examples and documentation

### DIFF
--- a/src/pages/ui/toggle-group.mdx
+++ b/src/pages/ui/toggle-group.mdx
@@ -38,6 +38,167 @@ import { ToggleGroup, ToggleGroupItem } from "~/components/ui/toggle-group";
 </ToggleGroup>
 ```
 
+## Examples
+
+Here are the source code of all the examples from the preview page:
+
+### Basic
+
+```tsx
+import { Bold, Italic, Underline } from "lucide-solid";
+import { ToggleGroup, ToggleGroupItem } from "~/components/ui/toggle-group";
+```
+
+```tsx file=../../registry/examples/toggle-group-example.tsx#L45-L61
+
+```
+
+### Outline
+
+```tsx
+import { ToggleGroup, ToggleGroupItem } from "~/components/ui/toggle-group";
+```
+
+```tsx file=../../registry/examples/toggle-group-example.tsx#L63-L76
+
+```
+
+### Outline With Icons
+
+```tsx
+import { Bold, Italic, Underline } from "lucide-solid";
+import { ToggleGroup, ToggleGroupItem } from "~/components/ui/toggle-group";
+```
+
+```tsx file=../../registry/examples/toggle-group-example.tsx#L78-L94
+
+```
+
+### Sizes
+
+```tsx
+import { ToggleGroup, ToggleGroupItem } from "~/components/ui/toggle-group";
+```
+
+```tsx file=../../registry/examples/toggle-group-example.tsx#L96-L131
+
+```
+
+### With Spacing
+
+Use `spacing={2}` to add spacing between toggle group items.
+
+```tsx
+import { ToggleGroup, ToggleGroupItem } from "~/components/ui/toggle-group";
+```
+
+```tsx file=../../registry/examples/toggle-group-example.tsx#L133-L152
+
+```
+
+### With Icons
+
+```tsx
+import { Bookmark, Heart, Star } from "lucide-solid";
+import { ToggleGroup, ToggleGroupItem } from "~/components/ui/toggle-group";
+```
+
+```tsx file=../../registry/examples/toggle-group-example.tsx#L154-L185
+
+```
+
+### Filter
+
+```tsx
+import { ToggleGroup, ToggleGroupItem } from "~/components/ui/toggle-group";
+```
+
+```tsx file=../../registry/examples/toggle-group-example.tsx#L187-L206
+
+```
+
+### Date Range
+
+```tsx
+import { ToggleGroup, ToggleGroupItem } from "~/components/ui/toggle-group";
+```
+
+```tsx file=../../registry/examples/toggle-group-example.tsx#L208-L227
+
+```
+
+### Sort
+
+```tsx
+import { ArrowDown, ArrowUp, TrendingUp } from "lucide-solid";
+import { ToggleGroup, ToggleGroupItem } from "~/components/ui/toggle-group";
+```
+
+```tsx file=../../registry/examples/toggle-group-example.tsx#L229-L248
+
+```
+
+### With Input and Select
+
+```tsx
+import { Input } from "~/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "~/components/ui/select";
+import { ToggleGroup, ToggleGroupItem } from "~/components/ui/toggle-group";
+```
+
+```tsx file=../../registry/examples/toggle-group-example.tsx#L250-L289
+
+```
+
+### Vertical
+
+```tsx
+import { Bold, Italic, Underline } from "lucide-solid";
+import { ToggleGroup, ToggleGroupItem } from "~/components/ui/toggle-group";
+```
+
+```tsx file=../../registry/examples/toggle-group-example.tsx#L291-L307
+
+```
+
+### Vertical Outline
+
+```tsx
+import { ToggleGroup, ToggleGroupItem } from "~/components/ui/toggle-group";
+```
+
+```tsx file=../../registry/examples/toggle-group-example.tsx#L309-L334
+
+```
+
+### Vertical Outline With Icons
+
+```tsx
+import { Bold, Italic, Underline } from "lucide-solid";
+import { ToggleGroup, ToggleGroupItem } from "~/components/ui/toggle-group";
+```
+
+```tsx file=../../registry/examples/toggle-group-example.tsx#L336-L352
+
+```
+
+### Vertical With Spacing
+
+```tsx
+import { ToggleGroup, ToggleGroupItem } from "~/components/ui/toggle-group";
+```
+
+```tsx file=../../registry/examples/toggle-group-example.tsx#L354-L380
+
+```
+
 ## API Reference
 
 ### ToggleGroup

--- a/src/registry/examples/toggle-group-example.tsx
+++ b/src/registry/examples/toggle-group-example.tsx
@@ -10,6 +10,15 @@ import {
   Underline,
 } from "lucide-solid";
 import { Example, ExampleWrapper } from "@/components/example";
+import { Input } from "@/registry/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/registry/ui/select";
 import { ToggleGroup, ToggleGroupItem } from "@/registry/ui/toggle-group";
 
 export default function ToggleGroupExample() {
@@ -24,7 +33,7 @@ export default function ToggleGroupExample() {
       <ToggleGroupFilter />
       <ToggleGroupDateRange />
       <ToggleGroupSort />
-      {/* <ToggleGroupWithInputAndSelect /> */}
+      <ToggleGroupWithInputAndSelect />
       <ToggleGroupVertical />
       <ToggleGroupVerticalOutline />
       <ToggleGroupVerticalOutlineWithIcons />
@@ -238,42 +247,46 @@ function ToggleGroupSort() {
   );
 }
 
-// function ToggleGroupWithInputAndSelect() {
-//   const items = [
-//     { label: "All", value: "all" },
-//     { label: "Active", value: "active" },
-//     { label: "Archived", value: "archived" },
-//   ];
-//   return (
-//     <Example title="With Input and Select">
-//       <div class="flex items-center gap-2">
-//         <Input type="search" placeholder="Search..." class="flex-1" />
-//         <Select items={items} defaultValue={items[0]}>
-//           <SelectTrigger class="w-32">
-//             <SelectValue />
-//           </SelectTrigger>
-//           <SelectContent>
-//             <SelectGroup>
-//               {items.map((item) => (
-//                 <SelectItem key={item.value} value={item.value}>
-//                   {item.label}
-//                 </SelectItem>
-//               ))}
-//             </SelectGroup>
-//           </SelectContent>
-//         </Select>
-//         <ToggleGroup defaultValue={["grid"]} variant="outline">
-//           <ToggleGroupItem value="grid" aria-label="Grid view">
-//             Grid
-//           </ToggleGroupItem>
-//           <ToggleGroupItem value="list" aria-label="List view">
-//             List
-//           </ToggleGroupItem>
-//         </ToggleGroup>
-//       </div>
-//     </Example>
-//   );
-// }
+function ToggleGroupWithInputAndSelect() {
+  const items = [
+    { label: "All", value: "all" },
+    { label: "Active", value: "active" },
+    { label: "Archived", value: "archived" },
+  ];
+  return (
+    <Example title="With Input and Select">
+      <div class="flex items-center gap-2">
+        <Input type="search" placeholder="Search..." class="flex-1" />
+        <Select
+          options={items}
+          optionValue="value"
+          optionTextValue="label"
+          defaultValue={items[0]}
+          itemComponent={(props) => (
+            <SelectItem item={props.item}>{props.item.rawValue.label}</SelectItem>
+          )}
+        >
+          <SelectTrigger class="w-32">
+            <SelectValue<(typeof items)[number]>>
+              {(state) => state.selectedOption().label}
+            </SelectValue>
+          </SelectTrigger>
+          <SelectContent>
+            <SelectGroup />
+          </SelectContent>
+        </Select>
+        <ToggleGroup multiple={false} defaultValue="grid" variant="outline">
+          <ToggleGroupItem value="grid" aria-label="Grid view">
+            Grid
+          </ToggleGroupItem>
+          <ToggleGroupItem value="list" aria-label="List view">
+            List
+          </ToggleGroupItem>
+        </ToggleGroup>
+      </div>
+    </Example>
+  );
+}
 
 function ToggleGroupVertical() {
   return (

--- a/tests/toggle-group.spec.ts
+++ b/tests/toggle-group.spec.ts
@@ -1,0 +1,248 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Toggle Group Component", () => {
+  test("examples", async ({ page }) => {
+    await page.goto("http://localhost:5175/ui/toggle-group");
+
+    await page.waitForLoadState("networkidle");
+
+    // ------------------------------------------------------------
+    // Basic Example - Multiple selection toggle group
+    // ------------------------------------------------------------
+
+    // 1. Get the basic section
+    const basicSection = page.getByText("Basic", { exact: true }).locator("..");
+
+    // 2. Click the 'Toggle bold' button
+    await basicSection.getByRole("button", { name: "Toggle bold" }).click();
+
+    // 3. Verify the bold button is pressed
+    await expect(basicSection.getByRole("button", { name: "Toggle bold" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+
+    // 4. Click the 'Toggle italic' button
+    await basicSection.getByRole("button", { name: "Toggle italic" }).click();
+
+    // 5. Verify both bold and italic are pressed (multiple selection)
+    await expect(basicSection.getByRole("button", { name: "Toggle bold" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    await expect(basicSection.getByRole("button", { name: "Toggle italic" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+
+    // 6. Click bold again to deselect
+    await basicSection.getByRole("button", { name: "Toggle bold" }).click();
+
+    // 7. Verify bold is no longer pressed
+    await expect(basicSection.getByRole("button", { name: "Toggle bold" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+
+    // ------------------------------------------------------------
+    // Outline Example - Single selection toggle group
+    // ------------------------------------------------------------
+
+    // 8. Get the outline section
+    const outlineSection = page.getByText("Outline", { exact: true }).first().locator("..");
+
+    // 9. Verify 'All' is initially selected
+    await expect(outlineSection.getByRole("button", { name: "Toggle all" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+
+    // 10. Click 'Toggle missed' button
+    await outlineSection.getByRole("button", { name: "Toggle missed" }).click();
+
+    // 11. Verify 'Missed' is now selected and 'All' is deselected (single selection)
+    await expect(outlineSection.getByRole("button", { name: "Toggle missed" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    await expect(outlineSection.getByRole("button", { name: "Toggle all" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+
+    // ------------------------------------------------------------
+    // With Icons Example - Multiple selection with icon fill
+    // ------------------------------------------------------------
+
+    // 12. Get the with icons section
+    const withIconsSection = page.getByText("With Icons", { exact: true }).first().locator("..");
+
+    // 13. Click the 'Toggle star' button
+    await withIconsSection.getByRole("button", { name: "Toggle star" }).click();
+
+    // 14. Verify star is pressed
+    await expect(withIconsSection.getByRole("button", { name: "Toggle star" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+
+    // 15. Click the 'Toggle heart' button
+    await withIconsSection.getByRole("button", { name: "Toggle heart" }).click();
+
+    // 16. Verify both star and heart are pressed
+    await expect(withIconsSection.getByRole("button", { name: "Toggle star" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    await expect(withIconsSection.getByRole("button", { name: "Toggle heart" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+
+    // ------------------------------------------------------------
+    // Filter Example - Single selection
+    // ------------------------------------------------------------
+
+    // 17. Get the filter section
+    const filterSection = page.getByText("Filter", { exact: true }).locator("..");
+
+    // 18. Click 'Active' button
+    await filterSection.getByRole("button", { name: "Active" }).click();
+
+    // 19. Verify 'Active' is selected
+    await expect(filterSection.getByRole("button", { name: "Active" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+
+    // 20. Click 'Completed' button
+    await filterSection.getByRole("button", { name: "Completed" }).click();
+
+    // 21. Verify 'Completed' is selected and 'Active' is deselected
+    await expect(filterSection.getByRole("button", { name: "Completed" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    await expect(filterSection.getByRole("button", { name: "Active" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+
+    // ------------------------------------------------------------
+    // Sort Example - Single selection with icons
+    // ------------------------------------------------------------
+
+    // 22. Get the sort section
+    const sortSection = page.getByText("Sort", { exact: true }).locator("..");
+
+    // 23. Verify 'Newest' is initially selected
+    await expect(sortSection.getByRole("button", { name: "Newest" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+
+    // 24. Click 'Oldest' button
+    await sortSection.getByRole("button", { name: "Oldest" }).click();
+
+    // 25. Verify 'Oldest' is selected
+    await expect(sortSection.getByRole("button", { name: "Oldest" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+
+    // ------------------------------------------------------------
+    // With Input and Select Example
+    // ------------------------------------------------------------
+
+    // 26. Get the with input and select section
+    const withInputSection = page.getByText("With Input and Select", { exact: true }).locator("..");
+
+    // 27. Verify search input is visible
+    await expect(withInputSection.getByRole("searchbox", { name: "Search..." })).toBeVisible();
+
+    // 28. Verify Grid view is selected by default
+    await expect(withInputSection.getByRole("button", { name: "Grid view" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+
+    // 29. Click List view button
+    await withInputSection.getByRole("button", { name: "List view" }).click();
+
+    // 30. Verify List view is now selected
+    await expect(withInputSection.getByRole("button", { name: "List view" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+
+    // ------------------------------------------------------------
+    // Vertical Example - Multiple selection vertical
+    // ------------------------------------------------------------
+
+    // 31. Get the vertical section
+    const verticalSection = page.getByText("Vertical", { exact: true }).first().locator("..");
+
+    // 32. Click 'Toggle underline' in vertical section
+    await verticalSection.getByRole("button", { name: "Toggle underline" }).click();
+
+    // 33. Verify underline is pressed
+    await expect(verticalSection.getByRole("button", { name: "Toggle underline" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+
+    // ------------------------------------------------------------
+    // Vertical Outline Example - Single selection vertical
+    // ------------------------------------------------------------
+
+    // 34. Get the vertical outline section
+    const verticalOutlineSection = page
+      .getByText("Vertical Outline", { exact: true })
+      .first()
+      .locator("..");
+
+    // 35. Verify 'All' is initially selected
+    await expect(
+      verticalOutlineSection.getByRole("button", { name: "Toggle all" }),
+    ).toHaveAttribute("aria-pressed", "true");
+
+    // 36. Click 'Toggle active' button
+    await verticalOutlineSection.getByRole("button", { name: "Toggle active" }).click();
+
+    // 37. Verify 'Active' is selected
+    await expect(
+      verticalOutlineSection.getByRole("button", { name: "Toggle active" }),
+    ).toHaveAttribute("aria-pressed", "true");
+
+    // ------------------------------------------------------------
+    // Docs Page Test - Toggle to Docs and Scroll
+    // ------------------------------------------------------------
+
+    // 38. Click the toggle button to switch to docs view
+    await page.getByRole("button", { name: "Toggle between preview and docs" }).click();
+
+    // 39. Wait for docs to load
+    await page.waitForTimeout(1000);
+
+    // 40. Verify the docs page is visible by checking for the main heading
+    await expect(page.getByRole("heading", { name: "Toggle Group", level: 1 })).toBeVisible();
+
+    // 41. Verify the Installation section is present
+    await expect(page.getByRole("heading", { name: "Installation", level: 2 })).toBeVisible();
+
+    // 42. Verify the Usage section is present
+    await expect(page.getByRole("heading", { name: "Usage", level: 2 })).toBeVisible();
+
+    // 43. Verify the Examples section is present
+    await expect(page.getByRole("heading", { name: "Examples", level: 2 })).toBeVisible();
+
+    // 44. Scroll to the bottom to see all examples
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+
+    // 45. Wait for scroll
+    await page.waitForTimeout(500);
+
+    // 46. Verify the API Reference section is visible
+    await expect(page.getByRole("heading", { name: "API Reference", level: 2 })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

- Sync examples from Shadcn UI for toggle-group component
- Transform React patterns to SolidJS (className → class, React Select → Kobalte Select)
- Update MDX documentation with Examples section containing all 14 examples
- Add Playwright test suite for component validation

## Changes

### Examples Updated
- **Basic** - Multiple selection toggle with icons
- **Outline** - Single selection outline variant
- **Outline With Icons** - Small outline with icons
- **Sizes** - Small and default size comparison
- **With Spacing** - Toggle group with spacing
- **With Icons** - Star/Heart/Bookmark with fill animation
- **Filter** - Filter options toggle
- **Date Range** - Date range selector
- **Sort** - Sort direction with icons
- **With Input and Select** - Combined with Input and Kobalte Select
- **Vertical** - Vertical orientation
- **Vertical Outline** - Vertical outline variant
- **Vertical Outline With Icons** - Vertical outline with icons
- **Vertical With Spacing** - Vertical with spacing

### Files Changed

- `src/registry/examples/toggle-group-example.tsx` - Component examples with ToggleGroupWithInputAndSelect enabled
- `src/pages/ui/toggle-group.mdx` - Documentation with all example code snippets
- `tests/toggle-group.spec.ts` - Playwright test suite

## Validation

- [x] Type checking passes (pre-existing velite errors unrelated to changes)
- [x] Playwright visual validation completed
- [x] Playwright test suite passes (1 test, all assertions pass)

## Video

[QA Video](https://okesuto.carere.dev/toggle-group-qa-video.webm)

---

🤖 Generated with [Claude Code](https://claude.ai/code)