### PR TITLE
feat(docs): sync textarea examples and documentation

### DIFF
--- a/src/pages/ui/textarea.mdx
+++ b/src/pages/ui/textarea.mdx
@@ -33,3 +33,60 @@ import { Textarea } from "~/components/ui/textarea";
 ```tsx showLineNumbers
 <Textarea placeholder="Type your message here." />
 ```
+
+## Examples
+
+Here are the source code of all the examples from the preview page:
+
+### Basic
+
+```tsx
+import { Textarea } from "~/components/ui/textarea";
+```
+
+```tsx file=../../registry/examples/textarea-example.tsx#L17-L23
+
+```
+
+### Invalid
+
+```tsx
+import { Textarea } from "~/components/ui/textarea";
+```
+
+```tsx file=../../registry/examples/textarea-example.tsx#L25-L31
+
+```
+
+### With Label
+
+```tsx
+import { Field, FieldLabel } from "~/components/ui/field";
+import { Textarea } from "~/components/ui/textarea";
+```
+
+```tsx file=../../registry/examples/textarea-example.tsx#L33-L42
+
+```
+
+### With Description
+
+```tsx
+import { Field, FieldDescription, FieldLabel } from "~/components/ui/field";
+import { Textarea } from "~/components/ui/textarea";
+```
+
+```tsx file=../../registry/examples/textarea-example.tsx#L44-L54
+
+```
+
+### Disabled
+
+```tsx
+import { Field, FieldLabel } from "~/components/ui/field";
+import { Textarea } from "~/components/ui/textarea";
+```
+
+```tsx file=../../registry/examples/textarea-example.tsx#L56-L65
+
+```

--- a/src/registry/examples/textarea-example.tsx
+++ b/src/registry/examples/textarea-example.tsx
@@ -1,4 +1,5 @@
 import { Example, ExampleWrapper } from "@/components/example";
+import { Field, FieldDescription, FieldLabel } from "@/registry/ui/field";
 import { Textarea } from "@/registry/ui/textarea";
 
 export default function TextareaExample() {
@@ -24,7 +25,7 @@ function TextareaBasic() {
 function TextareaInvalid() {
   return (
     <Example title="Invalid">
-      <Textarea aria-invalid="true" placeholder="Type your message here." />
+      <Textarea placeholder="Type your message here." aria-invalid="true" />
     </Example>
   );
 }
@@ -32,15 +33,10 @@ function TextareaInvalid() {
 function TextareaWithLabel() {
   return (
     <Example title="With Label">
-      <div class="grid w-full gap-1.5">
-        <label
-          for="message"
-          class="font-medium text-sm leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-        >
-          Message
-        </label>
-        <Textarea id="message" placeholder="Type your message here." rows={4} />
-      </div>
+      <Field>
+        <FieldLabel for="textarea-demo-message">Message</FieldLabel>
+        <Textarea id="textarea-demo-message" placeholder="Type your message here." rows={6} />
+      </Field>
     </Example>
   );
 }
@@ -48,16 +44,11 @@ function TextareaWithLabel() {
 function TextareaWithDescription() {
   return (
     <Example title="With Description">
-      <div class="grid w-full gap-1.5">
-        <label
-          for="message-2"
-          class="font-medium text-sm leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-        >
-          Message
-        </label>
-        <Textarea id="message-2" placeholder="Type your message here." />
-        <p class="text-muted-foreground text-sm">Type your message and press enter to send.</p>
-      </div>
+      <Field>
+        <FieldLabel for="textarea-demo-message-2">Message</FieldLabel>
+        <Textarea id="textarea-demo-message-2" placeholder="Type your message here." rows={6} />
+        <FieldDescription>Type your message and press enter to send.</FieldDescription>
+      </Field>
     </Example>
   );
 }
@@ -65,7 +56,10 @@ function TextareaWithDescription() {
 function TextareaDisabled() {
   return (
     <Example title="Disabled">
-      <Textarea placeholder="Type your message here." disabled />
+      <Field>
+        <FieldLabel for="textarea-demo-disabled">Message</FieldLabel>
+        <Textarea id="textarea-demo-disabled" placeholder="Type your message here." disabled />
+      </Field>
     </Example>
   );
 }

--- a/tests/textarea.spec.ts
+++ b/tests/textarea.spec.ts
@@ -1,0 +1,148 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Textarea Component", () => {
+  test("examples", async ({ page }) => {
+    await page.goto("http://localhost:5179/ui/textarea");
+
+    await page.waitForLoadState("networkidle");
+
+    // ------------------------------------------------------------
+    // Basic Example
+    // ------------------------------------------------------------
+
+    // 1. Get the basic section
+    const basicSection = page.getByText("Basic", { exact: true }).locator("..");
+
+    // 2. Verify the textarea is visible
+    const basicTextarea = basicSection.getByRole("textbox", { name: "Type your message here." });
+    await expect(basicTextarea).toBeVisible();
+
+    // 3. Type in the textarea
+    await basicTextarea.fill("Hello, this is a test message!");
+
+    // 4. Verify the text was entered
+    await expect(basicTextarea).toHaveValue("Hello, this is a test message!");
+
+    // 5. Clear the textarea
+    await basicTextarea.clear();
+    await expect(basicTextarea).toHaveValue("");
+
+    // ------------------------------------------------------------
+    // Invalid Example
+    // ------------------------------------------------------------
+
+    // 6. Get the invalid section
+    const invalidSection = page.getByText("Invalid", { exact: true }).locator("..");
+
+    // 7. Verify the invalid textarea is visible
+    const invalidTextarea = invalidSection.getByRole("textbox", {
+      name: "Type your message here.",
+    });
+    await expect(invalidTextarea).toBeVisible();
+
+    // 8. Verify the textarea has aria-invalid attribute
+    await expect(invalidTextarea).toHaveAttribute("aria-invalid", "true");
+
+    // 9. Type in the invalid textarea
+    await invalidTextarea.fill("This field is marked as invalid");
+
+    // 10. Verify the text was entered
+    await expect(invalidTextarea).toHaveValue("This field is marked as invalid");
+
+    // ------------------------------------------------------------
+    // With Label Example
+    // ------------------------------------------------------------
+
+    // 11. Get the with label section
+    const withLabelSection = page.getByText("With Label", { exact: true }).locator("..");
+
+    // 12. Verify the label is visible
+    await expect(withLabelSection.getByText("Message", { exact: true })).toBeVisible();
+
+    // 13. Verify the textarea is visible and has the correct id
+    const labeledTextarea = withLabelSection.getByRole("textbox", { name: "Message" });
+    await expect(labeledTextarea).toBeVisible();
+
+    // 14. Type in the labeled textarea
+    await labeledTextarea.fill("Message with label");
+
+    // 15. Verify the text was entered
+    await expect(labeledTextarea).toHaveValue("Message with label");
+
+    // ------------------------------------------------------------
+    // With Description Example
+    // ------------------------------------------------------------
+
+    // 16. Get the with description section
+    const withDescriptionSection = page
+      .getByText("With Description", { exact: true })
+      .locator("..");
+
+    // 17. Verify the label is visible
+    await expect(withDescriptionSection.getByText("Message").first()).toBeVisible();
+
+    // 18. Verify the description is visible
+    await expect(
+      withDescriptionSection.getByText("Type your message and press enter to send."),
+    ).toBeVisible();
+
+    // 19. Verify the textarea is visible
+    const descriptionTextarea = withDescriptionSection.getByRole("textbox", { name: "Message" });
+    await expect(descriptionTextarea).toBeVisible();
+
+    // 20. Type in the textarea with description
+    await descriptionTextarea.fill("Message with description");
+
+    // 21. Verify the text was entered
+    await expect(descriptionTextarea).toHaveValue("Message with description");
+
+    // ------------------------------------------------------------
+    // Disabled Example
+    // ------------------------------------------------------------
+
+    // 22. Get the disabled section
+    const disabledSection = page.getByText("Disabled", { exact: true }).locator("..");
+
+    // 23. Verify the disabled textarea is visible
+    const disabledTextarea = disabledSection.getByRole("textbox", { name: "Message" });
+    await expect(disabledTextarea).toBeVisible();
+
+    // 24. Verify the textarea is disabled
+    await expect(disabledTextarea).toBeDisabled();
+
+    // ------------------------------------------------------------
+    // Docs Page Test - Toggle to Docs and Scroll
+    // ------------------------------------------------------------
+
+    // 25. Click the toggle button to switch to docs view
+    await page.getByRole("button", { name: "Toggle between preview and docs" }).click();
+
+    // 26. Wait for the docs page to load
+    await page.waitForTimeout(500);
+
+    // 27. Verify the docs page is visible by checking for the main heading
+    await expect(page.getByRole("heading", { name: "Textarea", level: 1 })).toBeVisible();
+
+    // 28. Verify the Installation section is present
+    await expect(page.getByRole("heading", { name: "Installation", level: 2 })).toBeVisible();
+
+    // 29. Verify the Usage section is present
+    await expect(page.getByRole("heading", { name: "Usage", level: 2 })).toBeVisible();
+
+    // 30. Verify the Examples section is present
+    await expect(page.getByRole("heading", { name: "Examples", level: 2 })).toBeVisible();
+
+    // 31. Scroll to the bottom of the page to see all examples
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+
+    // 32. Wait for scroll to complete
+    await page.waitForTimeout(300);
+
+    // 33. Verify example sections are visible in docs
+    await expect(page.getByRole("heading", { name: "Basic", level: 3 })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Invalid", level: 3 })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "With Label", level: 3 })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "With Description", level: 3 })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Disabled", level: 3 })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

- Sync examples from Shadcn UI for textarea component
- Transform React patterns to SolidJS (htmlFor → for, using Field/FieldLabel/FieldDescription components)
- Update MDX documentation with Examples section

## Changes

- `src/registry/examples/textarea-example.tsx` - Updated to use Field, FieldLabel, FieldDescription components matching Shadcn patterns
- `src/pages/ui/textarea.mdx` - Added Examples section with all 5 example variants
- `tests/textarea.spec.ts` - New Playwright test suite for textarea component

## Example Variants Synced

1. **Basic** - Simple textarea with placeholder
2. **Invalid** - Textarea with aria-invalid state
3. **With Label** - Textarea with Field/FieldLabel
4. **With Description** - Textarea with Field/FieldLabel/FieldDescription
5. **Disabled** - Disabled textarea with Field/FieldLabel

## Validation

- [x] Type checking passes
- [x] Playwright visual validation completed
- [x] Playwright test suite passes (1 test, all assertions pass)

## Video

[QA Video](https://okesuto.carere.dev/textarea-qa-video.webm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)