### PR TITLE
feat(docs): sync sonner examples and documentation

### DIFF
--- a/src/pages/ui/sonner.mdx
+++ b/src/pages/ui/sonner.mdx
@@ -1,12 +1,12 @@
 ---
 title: Sonner
 slug: sonner
-description: An opinionated toast component for SolidJS with stacking animations.
+description: An opinionated toast component for SolidJS.
 ---
 
 # Sonner
 
-An opinionated toast component for SolidJS built on [Kobalte Toast](https://kobalte.dev/docs/core/components/toast). Features a stacking animation where multiple toasts stack behind the front toast and expand on hover.
+An opinionated toast component for SolidJS.
 
 ## Installation
 
@@ -18,6 +18,12 @@ shadcn@latest add sonner
 
 ### Manual
 
+Install the following dependencies:
+
+```package-install
+solid-sonner
+```
+
 Copy and paste the following code into your project.
 
 ```tsx file=../../registry/ui/sonner.tsx showLineNumbers
@@ -27,7 +33,8 @@ Copy and paste the following code into your project.
 ## Usage
 
 ```tsx
-import { toast, Toaster } from "~/components/ui/sonner";
+import { Toaster } from "~/components/ui/sonner";
+import { toast } from "solid-sonner";
 ```
 
 Add the `Toaster` component to your app root:
@@ -45,14 +52,13 @@ export default function App() {
 }
 ```
 
-Then use the `toast` API to show notifications:
+Then use the `toast` function to show notifications:
 
 ```tsx showLineNumbers
-toast.show("Event has been created");
+toast("Event has been created");
 
 // With description
-toast.show({
-  title: "Event has been created",
+toast("Event has been created", {
   description: "Monday, January 3rd at 6:00pm",
 });
 
@@ -64,120 +70,28 @@ toast.info("Information");
 toast.loading("Loading...");
 ```
 
-## Stacking Behavior
+## Examples
 
-When multiple toasts are displayed:
+Here are the source code of all the examples from the preview page:
 
-1. The most recent toast is fully visible at the front
-2. Older toasts stack behind with reduced scale and opacity
-3. When you hover over the toast area, all toasts expand into a column
-4. After moving your mouse away, toasts collapse back to the stacked view
+### Basic
 
-This behavior can be controlled with the `expand` prop:
-
-```tsx showLineNumbers
-// Disable stacking/expand behavior
-<Toaster expand={false} />
-
-// Customize collapse delay (default: 200ms)
-<Toaster closeDelay={500} />
+```tsx
+import { toast } from "solid-sonner";
+import { Button } from "~/components/ui/button";
 ```
 
-## Toast Variants
+```tsx file=../../registry/examples/sonner-example.tsx#L18-L25
 
-The toast component supports multiple variants:
-
-```tsx showLineNumbers
-// Default toast
-toast.show("Default message");
-
-// Success toast with green icon
-toast.success("Your changes have been saved!");
-
-// Error toast with red icon
-toast.error("Something went wrong");
-
-// Warning toast with amber icon
-toast.warning("Please review your input");
-
-// Info toast with blue icon
-toast.info("Here's some information");
-
-// Loading toast with spinner
-toast.loading("Processing...");
 ```
 
-## Promise Toast
+### With Description
 
-Show different states based on a promise:
-
-```tsx showLineNumbers
-toast.promise(
-  fetch("/api/data"),
-  {
-    loading: "Loading data...",
-    success: "Data loaded successfully!",
-    error: "Failed to load data",
-  }
-);
-
-// With dynamic messages
-toast.promise(
-  saveData(),
-  {
-    loading: { title: "Saving...", description: "Please wait" },
-    success: (data) => ({ title: "Saved!", description: `ID: ${data.id}` }),
-    error: (err) => ({ title: "Error", description: err.message }),
-  }
-);
+```tsx
+import { toast } from "solid-sonner";
+import { Button } from "~/components/ui/button";
 ```
 
-## Toaster Position
+```tsx file=../../registry/examples/sonner-example.tsx#L27-L42
 
-Position the toasts at different locations (default is `top-center`):
-
-```tsx showLineNumbers
-<Toaster position="top-right" />
-<Toaster position="top-center" />
-<Toaster position="top-left" />
-<Toaster position="bottom-right" />
-<Toaster position="bottom-center" />
-<Toaster position="bottom-left" />
 ```
-
-## API Reference
-
-### toast
-
-| Method | Description |
-| --- | --- |
-| `toast.show(options)` | Show a toast with the specified options |
-| `toast.success(options)` | Show a success toast |
-| `toast.error(options)` | Show an error toast |
-| `toast.warning(options)` | Show a warning toast |
-| `toast.info(options)` | Show an info toast |
-| `toast.loading(options)` | Show a loading toast |
-| `toast.promise(promise, options)` | Show a toast that updates based on promise state |
-| `toast.dismiss(id)` | Dismiss a toast by ID |
-| `toast.clear()` | Clear all toasts |
-
-### ToastOptions
-
-| Property | Type | Description |
-| --- | --- | --- |
-| `title` | `string` | The title of the toast |
-| `description` | `string` | The description of the toast |
-| `duration` | `number` | Duration in milliseconds before auto-dismiss |
-| `action` | `JSX.Element` | Action element to render |
-
-### Toaster Props
-
-| Property | Type | Default | Description |
-| --- | --- | --- | --- |
-| `position` | `string` | `"top-center"` | Position of the toast container |
-| `duration` | `number` | `5000` | Default duration for toasts |
-| `limit` | `number` | `3` | Maximum number of visible toasts |
-| `gap` | `number` | `14` | Gap between toasts when expanded (in pixels) |
-| `expand` | `boolean` | `true` | Whether to expand toasts on hover |
-| `closeDelay` | `number` | `200` | Delay before collapsing after mouse leaves (in ms) |
-| `swipeDirection` | `"up" \| "down" \| "left" \| "right"` | `"right"` | Direction to swipe to dismiss |

--- a/tests/sonner.spec.ts
+++ b/tests/sonner.spec.ts
@@ -1,0 +1,87 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Sonner Examples", () => {
+  test("examples", async ({ page }) => {
+    await page.goto("/ui/sonner");
+
+    await page.waitForLoadState("networkidle");
+
+    // ------------------------------------------------------------
+    // Basic Example
+    // ------------------------------------------------------------
+
+    // 1. Get the basic section
+    const basicSection = page.getByText("Basic", { exact: true }).locator("..");
+
+    // 2. Hover over the 'Show Toast' button
+    await basicSection.getByRole("button", { name: "Show Toast", exact: true }).hover();
+
+    // 3. Wait for 300ms to simulate user navigation
+    await page.waitForTimeout(300);
+
+    // 4. Click the 'Show Toast' button
+    await basicSection.getByRole("button", { name: "Show Toast", exact: true }).click();
+
+    // 5. Verify the toast is visible with correct text
+    const toast = page.getByRole("status").filter({ hasText: /^Event has been created$/ });
+    await expect(toast).toBeVisible();
+
+    // 6. Wait for toast to disappear
+    await page.waitForTimeout(4000);
+    await expect(toast).toBeHidden();
+
+    // ------------------------------------------------------------
+    // With Description Example
+    // ------------------------------------------------------------
+
+    // 7. Get the with description section
+    const withDescriptionSection = page
+      .getByText("With Description", { exact: true })
+      .locator("..");
+
+    // 8. Hover over the 'Show Toast' button
+    await withDescriptionSection.getByRole("button", { name: "Show Toast", exact: true }).hover();
+
+    // 9. Wait for 300ms to simulate user navigation
+    await page.waitForTimeout(300);
+
+    // 10. Click the 'Show Toast' button
+    await withDescriptionSection.getByRole("button", { name: "Show Toast", exact: true }).click();
+
+    // 11. Verify the toast is visible with correct text and description
+    const toastWithDescription = page
+      .getByRole("status")
+      .filter({ hasText: "Monday, January 3rd at 6:00pm" });
+    await expect(toastWithDescription).toBeVisible();
+    await expect(toastWithDescription).toContainText("Event has been created");
+
+    // 12. Wait for toast to disappear
+    await page.waitForTimeout(4000);
+    await expect(toastWithDescription).toBeHidden();
+
+    // ------------------------------------------------------------
+    // Docs Page Test - Toggle to Docs and Scroll
+    // ------------------------------------------------------------
+
+    // 13. Click the toggle button to switch to docs view
+    await page.getByRole("button", { name: "Toggle between preview and docs" }).click();
+
+    // 14. Wait for docs to load
+    await page.waitForTimeout(1000);
+
+    // 15. Verify the docs page is visible by checking for the main heading
+    await expect(page.getByRole("heading", { name: "Sonner" }).first()).toBeVisible();
+
+    // 16. Verify the Installation section is present
+    await expect(page.getByRole("heading", { name: "Installation" }).first()).toBeVisible();
+
+    // 17. Verify the Usage section is present
+    await expect(page.getByRole("heading", { name: "Usage" }).first()).toBeVisible();
+
+    // 18. Scroll to the bottom of the page to see all content
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+
+    // 19. Wait for scroll and content
+    await page.waitForTimeout(500);
+  });
+});


### PR DESCRIPTION
## Summary

- Sync examples from Shadcn UI for sonner component
- Transform React patterns to SolidJS
- Update MDX documentation with Examples section
- Add Playwright test suite for sonner examples

## Changes

### Documentation (`src/pages/ui/sonner.mdx`)
- Simplified documentation with correct solid-sonner usage
- Added Examples section with Basic and With Description examples
- Fixed import statements to use correct packages

### Tests (`tests/sonner.spec.ts`)
- Created Playwright test suite for sonner component
- Tests Basic toast functionality
- Tests With Description toast functionality
- Validates docs page navigation and content

## Validation

- [x] Type checking passes (pre-existing issues unrelated to changes)
- [x] Playwright visual validation completed
- [x] Playwright test suite passes

## Video

[QA Video](https://okesuto.carere.dev/sonner-qa-video.webm)

## Files Changed

- `src/pages/ui/sonner.mdx` - Documentation with Examples section
- `tests/sonner.spec.ts` - Playwright test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)