### PR TITLE
feat(docs): sync toggle examples and documentation

### DIFF
--- a/src/pages/ui/toggle-group.mdx
+++ b/src/pages/ui/toggle-group.mdx
@@ -38,6 +38,164 @@ import { ToggleGroup, ToggleGroupItem } from "~/components/ui/toggle-group";
 </ToggleGroup>
 ```
 
+## Examples
+
+Here are the source code of all the examples from the preview page:
+
+### Basic
+
+```tsx
+import { Bold, Italic, Underline } from "lucide-solid";
+import { ToggleGroup, ToggleGroupItem } from "~/components/ui/toggle-group";
+```
+
+```tsx file=../../registry/examples/toggle-group-example.tsx#L44-L60
+
+```
+
+### Outline
+
+```tsx
+import { ToggleGroup, ToggleGroupItem } from "~/components/ui/toggle-group";
+```
+
+```tsx file=../../registry/examples/toggle-group-example.tsx#L62-L75
+
+```
+
+### Outline With Icons
+
+```tsx
+import { Bold, Italic, Underline } from "lucide-solid";
+import { ToggleGroup, ToggleGroupItem } from "~/components/ui/toggle-group";
+```
+
+```tsx file=../../registry/examples/toggle-group-example.tsx#L77-L93
+
+```
+
+### Sizes
+
+```tsx
+import { ToggleGroup, ToggleGroupItem } from "~/components/ui/toggle-group";
+```
+
+```tsx file=../../registry/examples/toggle-group-example.tsx#L95-L130
+
+```
+
+### With Spacing
+
+```tsx
+import { ToggleGroup, ToggleGroupItem } from "~/components/ui/toggle-group";
+```
+
+```tsx file=../../registry/examples/toggle-group-example.tsx#L132-L151
+
+```
+
+### With Icons
+
+```tsx
+import { Bookmark, Heart, Star } from "lucide-solid";
+import { ToggleGroup, ToggleGroupItem } from "~/components/ui/toggle-group";
+```
+
+```tsx file=../../registry/examples/toggle-group-example.tsx#L153-L184
+
+```
+
+### Filter
+
+```tsx
+import { ToggleGroup, ToggleGroupItem } from "~/components/ui/toggle-group";
+```
+
+```tsx file=../../registry/examples/toggle-group-example.tsx#L186-L205
+
+```
+
+### Date Range
+
+```tsx
+import { ToggleGroup, ToggleGroupItem } from "~/components/ui/toggle-group";
+```
+
+```tsx file=../../registry/examples/toggle-group-example.tsx#L207-L226
+
+```
+
+### Sort
+
+```tsx
+import { ArrowDown, ArrowUp, TrendingUp } from "lucide-solid";
+import { ToggleGroup, ToggleGroupItem } from "~/components/ui/toggle-group";
+```
+
+```tsx file=../../registry/examples/toggle-group-example.tsx#L228-L247
+
+```
+
+### With Input and Select
+
+```tsx
+import { Input } from "~/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "~/components/ui/select";
+import { ToggleGroup, ToggleGroupItem } from "~/components/ui/toggle-group";
+```
+
+```tsx file=../../registry/examples/toggle-group-example.tsx#L249-L286
+
+```
+
+### Vertical
+
+```tsx
+import { Bold, Italic, Underline } from "lucide-solid";
+import { ToggleGroup, ToggleGroupItem } from "~/components/ui/toggle-group";
+```
+
+```tsx file=../../registry/examples/toggle-group-example.tsx#L288-L304
+
+```
+
+### Vertical Outline
+
+```tsx
+import { ToggleGroup, ToggleGroupItem } from "~/components/ui/toggle-group";
+```
+
+```tsx file=../../registry/examples/toggle-group-example.tsx#L306-L331
+
+```
+
+### Vertical Outline With Icons
+
+```tsx
+import { Bold, Italic, Underline } from "lucide-solid";
+import { ToggleGroup, ToggleGroupItem } from "~/components/ui/toggle-group";
+```
+
+```tsx file=../../registry/examples/toggle-group-example.tsx#L333-L349
+
+```
+
+### Vertical With Spacing
+
+```tsx
+import { ToggleGroup, ToggleGroupItem } from "~/components/ui/toggle-group";
+```
+
+```tsx file=../../registry/examples/toggle-group-example.tsx#L351-L377
+
+```
+
 ## API Reference
 
 ### ToggleGroup

--- a/src/pages/ui/toggle.mdx
+++ b/src/pages/ui/toggle.mdx
@@ -1,0 +1,141 @@
+---
+title: Toggle
+slug: toggle
+description: A two-state button that can be either on or off.
+---
+
+# Toggle
+
+A two-state button that can be either on or off.
+
+## Installation
+
+### CLI
+
+```package-dlx
+shadcn@latest add toggle
+```
+
+### Manual
+
+Copy and paste the following code into your project.
+
+```tsx file=../../registry/ui/toggle.tsx showLineNumbers
+
+```
+
+## Usage
+
+```tsx
+import { Toggle } from "~/components/ui/toggle";
+```
+
+```tsx showLineNumbers
+<Toggle>Toggle</Toggle>
+```
+
+## Examples
+
+Here are the source code of all the examples from the preview page:
+
+### Basic
+
+```tsx
+import { Bold, Italic, Underline } from "lucide-solid";
+import { Toggle } from "~/components/ui/toggle";
+```
+
+```tsx file=../../registry/examples/toggle-example.tsx#L21-L37
+
+```
+
+### Outline
+
+```tsx
+import { Bold, Italic } from "lucide-solid";
+import { Toggle } from "~/components/ui/toggle";
+```
+
+```tsx file=../../registry/examples/toggle-example.tsx#L39-L54
+
+```
+
+### Sizes
+
+```tsx
+import { Toggle } from "~/components/ui/toggle";
+```
+
+```tsx file=../../registry/examples/toggle-example.tsx#L56-L72
+
+```
+
+### With Button Text
+
+```tsx
+import { Button } from "~/components/ui/button";
+import { Toggle } from "~/components/ui/toggle";
+```
+
+```tsx file=../../registry/examples/toggle-example.tsx#L74-L105
+
+```
+
+### With Button Icon
+
+```tsx
+import { Bold, Italic, Underline } from "lucide-solid";
+import { Button } from "~/components/ui/button";
+import { Toggle } from "~/components/ui/toggle";
+```
+
+```tsx file=../../registry/examples/toggle-example.tsx#L107-L138
+
+```
+
+### With Button Icon + Text
+
+```tsx
+import { Bold, Italic, Underline } from "lucide-solid";
+import { Button } from "~/components/ui/button";
+import { Toggle } from "~/components/ui/toggle";
+```
+
+```tsx file=../../registry/examples/toggle-example.tsx#L140-L177
+
+```
+
+### Disabled
+
+```tsx
+import { Toggle } from "~/components/ui/toggle";
+```
+
+```tsx file=../../registry/examples/toggle-example.tsx#L179-L192
+
+```
+
+### With Icon
+
+```tsx
+import { Bookmark } from "lucide-solid";
+import { Toggle } from "~/components/ui/toggle";
+```
+
+```tsx file=../../registry/examples/toggle-example.tsx#L194-L208
+
+```
+
+## API Reference
+
+### Toggle
+
+| Prop | Type | Default |
+|------|------|---------|
+| `variant` | `"default" \| "outline"` | `"default"` |
+| `size` | `"default" \| "sm" \| "lg"` | `"default"` |
+| `pressed` | `boolean` | - |
+| `defaultPressed` | `boolean` | `false` |
+| `onChange` | `(pressed: boolean) => void` | - |
+| `disabled` | `boolean` | `false` |
+| `class` | `string` | - |

--- a/src/registry/examples/toggle-example.tsx
+++ b/src/registry/examples/toggle-example.tsx
@@ -1,0 +1,208 @@
+import { Bold, Bookmark, Italic, Underline } from "lucide-solid";
+import { Example, ExampleWrapper } from "@/components/example";
+import { Button } from "@/registry/ui/button";
+import { Toggle } from "@/registry/ui/toggle";
+
+export default function ToggleExample() {
+  return (
+    <ExampleWrapper>
+      <ToggleBasic />
+      <ToggleOutline />
+      <ToggleSizes />
+      <ToggleWithButtonText />
+      <ToggleWithButtonIcon />
+      <ToggleWithButtonIconText />
+      <ToggleDisabled />
+      <ToggleWithIcon />
+    </ExampleWrapper>
+  );
+}
+
+function ToggleBasic() {
+  return (
+    <Example title="Basic">
+      <div class="flex flex-wrap items-center gap-2">
+        <Toggle aria-label="Toggle bold" defaultPressed>
+          <Bold />
+        </Toggle>
+        <Toggle aria-label="Toggle italic">
+          <Italic />
+        </Toggle>
+        <Toggle aria-label="Toggle underline">
+          <Underline />
+        </Toggle>
+      </div>
+    </Example>
+  );
+}
+
+function ToggleOutline() {
+  return (
+    <Example title="Outline">
+      <div class="flex flex-wrap items-center gap-2">
+        <Toggle variant="outline" aria-label="Toggle italic">
+          <Italic />
+          Italic
+        </Toggle>
+        <Toggle variant="outline" aria-label="Toggle bold">
+          <Bold />
+          Bold
+        </Toggle>
+      </div>
+    </Example>
+  );
+}
+
+function ToggleSizes() {
+  return (
+    <Example title="Sizes">
+      <div class="flex flex-wrap items-center gap-2">
+        <Toggle variant="outline" aria-label="Toggle small" size="sm">
+          Small
+        </Toggle>
+        <Toggle variant="outline" aria-label="Toggle default" size="default">
+          Default
+        </Toggle>
+        <Toggle variant="outline" aria-label="Toggle large" size="lg">
+          Large
+        </Toggle>
+      </div>
+    </Example>
+  );
+}
+
+function ToggleWithButtonText() {
+  return (
+    <Example title="With Button Text">
+      <div class="flex flex-col gap-4">
+        <div class="flex items-center gap-2">
+          <Button size="sm" variant="outline">
+            Button
+          </Button>
+          <Toggle variant="outline" aria-label="Toggle sm" size="sm">
+            Toggle
+          </Toggle>
+        </div>
+        <div class="flex items-center gap-2">
+          <Button size="default" variant="outline">
+            Button
+          </Button>
+          <Toggle variant="outline" aria-label="Toggle default" size="default">
+            Toggle
+          </Toggle>
+        </div>
+        <div class="flex items-center gap-2">
+          <Button size="lg" variant="outline">
+            Button
+          </Button>
+          <Toggle variant="outline" aria-label="Toggle lg" size="lg">
+            Toggle
+          </Toggle>
+        </div>
+      </div>
+    </Example>
+  );
+}
+
+function ToggleWithButtonIcon() {
+  return (
+    <Example title="With Button Icon">
+      <div class="flex flex-col gap-4">
+        <div class="flex items-center gap-2">
+          <Button variant="outline" size="icon-sm">
+            <Bold />
+          </Button>
+          <Toggle variant="outline" aria-label="Toggle sm icon" size="sm">
+            <Bold />
+          </Toggle>
+        </div>
+        <div class="flex items-center gap-2">
+          <Button variant="outline" size="icon">
+            <Italic />
+          </Button>
+          <Toggle variant="outline" aria-label="Toggle default icon" size="default">
+            <Italic />
+          </Toggle>
+        </div>
+        <div class="flex items-center gap-2">
+          <Button variant="outline" size="icon-lg">
+            <Underline />
+          </Button>
+          <Toggle variant="outline" aria-label="Toggle lg icon" size="lg">
+            <Underline />
+          </Toggle>
+        </div>
+      </div>
+    </Example>
+  );
+}
+
+function ToggleWithButtonIconText() {
+  return (
+    <Example title="With Button Icon + Text">
+      <div class="flex flex-col gap-4">
+        <div class="flex items-center gap-2">
+          <Button size="sm" variant="outline">
+            <Bold data-icon="inline-start" />
+            Button
+          </Button>
+          <Toggle variant="outline" aria-label="Toggle sm icon text" size="sm">
+            <Bold />
+            Toggle
+          </Toggle>
+        </div>
+        <div class="flex items-center gap-2">
+          <Button size="default" variant="outline">
+            <Italic data-icon="inline-start" />
+            Button
+          </Button>
+          <Toggle variant="outline" aria-label="Toggle default icon text" size="default">
+            <Italic />
+            Toggle
+          </Toggle>
+        </div>
+        <div class="flex items-center gap-2">
+          <Button size="lg" variant="outline">
+            <Underline data-icon="inline-start" />
+            Button
+          </Button>
+          <Toggle variant="outline" aria-label="Toggle lg icon text" size="lg">
+            <Underline />
+            Toggle
+          </Toggle>
+        </div>
+      </div>
+    </Example>
+  );
+}
+
+function ToggleDisabled() {
+  return (
+    <Example title="Disabled">
+      <div class="flex flex-wrap items-center gap-2">
+        <Toggle aria-label="Toggle disabled" disabled>
+          Disabled
+        </Toggle>
+        <Toggle variant="outline" aria-label="Toggle disabled outline" disabled>
+          Disabled
+        </Toggle>
+      </div>
+    </Example>
+  );
+}
+
+function ToggleWithIcon() {
+  return (
+    <Example title="With Icon">
+      <div class="flex flex-wrap items-center gap-2">
+        <Toggle aria-label="Toggle bookmark" defaultPressed>
+          <Bookmark class="group-data-[pressed]/toggle:fill-accent-foreground" />
+        </Toggle>
+        <Toggle variant="outline" aria-label="Toggle bookmark outline">
+          <Bookmark class="group-data-[pressed]/toggle:fill-accent-foreground" />
+          Bookmark
+        </Toggle>
+      </div>
+    </Example>
+  );
+}

--- a/src/registry/examples/toggle-group-example.tsx
+++ b/src/registry/examples/toggle-group-example.tsx
@@ -10,6 +10,14 @@ import {
   Underline,
 } from "lucide-solid";
 import { Example, ExampleWrapper } from "@/components/example";
+import { Input } from "@/registry/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/registry/ui/select";
 import { ToggleGroup, ToggleGroupItem } from "@/registry/ui/toggle-group";
 
 export default function ToggleGroupExample() {
@@ -24,7 +32,7 @@ export default function ToggleGroupExample() {
       <ToggleGroupFilter />
       <ToggleGroupDateRange />
       <ToggleGroupSort />
-      {/* <ToggleGroupWithInputAndSelect /> */}
+      <ToggleGroupWithInputAndSelect />
       <ToggleGroupVertical />
       <ToggleGroupVerticalOutline />
       <ToggleGroupVerticalOutlineWithIcons />
@@ -238,42 +246,44 @@ function ToggleGroupSort() {
   );
 }
 
-// function ToggleGroupWithInputAndSelect() {
-//   const items = [
-//     { label: "All", value: "all" },
-//     { label: "Active", value: "active" },
-//     { label: "Archived", value: "archived" },
-//   ];
-//   return (
-//     <Example title="With Input and Select">
-//       <div class="flex items-center gap-2">
-//         <Input type="search" placeholder="Search..." class="flex-1" />
-//         <Select items={items} defaultValue={items[0]}>
-//           <SelectTrigger class="w-32">
-//             <SelectValue />
-//           </SelectTrigger>
-//           <SelectContent>
-//             <SelectGroup>
-//               {items.map((item) => (
-//                 <SelectItem key={item.value} value={item.value}>
-//                   {item.label}
-//                 </SelectItem>
-//               ))}
-//             </SelectGroup>
-//           </SelectContent>
-//         </Select>
-//         <ToggleGroup defaultValue={["grid"]} variant="outline">
-//           <ToggleGroupItem value="grid" aria-label="Grid view">
-//             Grid
-//           </ToggleGroupItem>
-//           <ToggleGroupItem value="list" aria-label="List view">
-//             List
-//           </ToggleGroupItem>
-//         </ToggleGroup>
-//       </div>
-//     </Example>
-//   );
-// }
+function ToggleGroupWithInputAndSelect() {
+  const items = [
+    { label: "All", value: "all" },
+    { label: "Active", value: "active" },
+    { label: "Archived", value: "archived" },
+  ];
+  return (
+    <Example title="With Input and Select">
+      <div class="flex items-center gap-2">
+        <Input type="search" placeholder="Search..." class="flex-1" />
+        <Select
+          options={items}
+          optionValue="value"
+          optionTextValue="label"
+          defaultValue={items[0]}
+          itemComponent={(props) => (
+            <SelectItem item={props.item}>{props.item.rawValue.label}</SelectItem>
+          )}
+        >
+          <SelectTrigger class="w-32">
+            <SelectValue<(typeof items)[number]>>
+              {(state) => state.selectedOption()?.label}
+            </SelectValue>
+          </SelectTrigger>
+          <SelectContent />
+        </Select>
+        <ToggleGroup multiple={false} defaultValue="grid" variant="outline">
+          <ToggleGroupItem value="grid" aria-label="Grid view">
+            Grid
+          </ToggleGroupItem>
+          <ToggleGroupItem value="list" aria-label="List view">
+            List
+          </ToggleGroupItem>
+        </ToggleGroup>
+      </div>
+    </Example>
+  );
+}
 
 function ToggleGroupVertical() {
   return (

--- a/tests/toggle-group.spec.ts
+++ b/tests/toggle-group.spec.ts
@@ -1,0 +1,188 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Toggle Group Examples", () => {
+  test("examples", async ({ page }) => {
+    await page.goto("http://localhost:5181/ui/toggle-group");
+
+    await page.waitForLoadState("networkidle");
+
+    // ------------------------------------------------------------
+    // Basic Example
+    // ------------------------------------------------------------
+
+    // 1. Get the basic section
+    const basicSection = page.getByText("Basic", { exact: true }).locator("..");
+
+    // 2. Click the bold toggle
+    const boldToggle = basicSection.getByRole("button", { name: "Toggle bold" });
+    await boldToggle.hover();
+    await page.waitForTimeout(300);
+    await boldToggle.click();
+
+    // 3. Verify bold toggle is now pressed
+    await expect(boldToggle).toHaveAttribute("aria-pressed", "true");
+
+    // 4. Click the italic toggle (multiple selection is enabled)
+    const italicToggle = basicSection.getByRole("button", { name: "Toggle italic" });
+    await italicToggle.hover();
+    await page.waitForTimeout(300);
+    await italicToggle.click();
+
+    // 5. Verify both are pressed (multiple mode)
+    await expect(boldToggle).toHaveAttribute("aria-pressed", "true");
+    await expect(italicToggle).toHaveAttribute("aria-pressed", "true");
+
+    // ------------------------------------------------------------
+    // Outline Example
+    // ------------------------------------------------------------
+
+    // 6. Get the outline section
+    const outlineSection = page.getByText("Outline", { exact: true }).locator("..");
+
+    // 7. Verify 'All' is selected by default
+    const allButton = outlineSection.getByRole("button", { name: "Toggle all" });
+    await expect(allButton).toHaveAttribute("aria-pressed", "true");
+
+    // 8. Click on 'Missed' (single selection mode)
+    const missedButton = outlineSection.getByRole("button", { name: "Toggle missed" });
+    await missedButton.hover();
+    await page.waitForTimeout(300);
+    await missedButton.click();
+
+    // 9. Verify 'Missed' is now selected and 'All' is not
+    await expect(missedButton).toHaveAttribute("aria-pressed", "true");
+    await expect(allButton).toHaveAttribute("aria-pressed", "false");
+
+    // ------------------------------------------------------------
+    // Sizes Example
+    // ------------------------------------------------------------
+
+    // 10. Get the sizes section
+    const sizesSection = page.getByText("Sizes", { exact: true }).locator("..");
+
+    // 11. Verify 'Top' is selected in both size groups
+    const topButtons = sizesSection.getByRole("button", { name: "Toggle top" });
+    await expect(topButtons.first()).toHaveAttribute("aria-pressed", "true");
+    await expect(topButtons.last()).toHaveAttribute("aria-pressed", "true");
+
+    // ------------------------------------------------------------
+    // Filter Example
+    // ------------------------------------------------------------
+
+    // 12. Get the filter section
+    const filterSection = page.getByText("Filter", { exact: true }).locator("..");
+
+    // 13. Verify 'All' is selected by default
+    const filterAll = filterSection.getByRole("button", { name: "All" });
+    await expect(filterAll).toHaveAttribute("aria-pressed", "true");
+
+    // 14. Click on 'Active'
+    const filterActive = filterSection.getByRole("button", { name: "Active" });
+    await filterActive.hover();
+    await page.waitForTimeout(300);
+    await filterActive.click();
+
+    // 15. Verify 'Active' is now selected
+    await expect(filterActive).toHaveAttribute("aria-pressed", "true");
+    await expect(filterAll).toHaveAttribute("aria-pressed", "false");
+
+    // ------------------------------------------------------------
+    // Sort Example
+    // ------------------------------------------------------------
+
+    // 16. Get the sort section
+    const sortSection = page.getByText("Sort", { exact: true }).locator("..");
+
+    // 17. Verify 'Newest' is selected by default
+    const newestButton = sortSection.getByRole("button", { name: "Newest" });
+    await expect(newestButton).toHaveAttribute("aria-pressed", "true");
+
+    // 18. Click on 'Popular'
+    const popularButton = sortSection.getByRole("button", { name: "Popular" });
+    await popularButton.hover();
+    await page.waitForTimeout(300);
+    await popularButton.click();
+
+    // 19. Verify 'Popular' is now selected
+    await expect(popularButton).toHaveAttribute("aria-pressed", "true");
+
+    // ------------------------------------------------------------
+    // With Input and Select Example
+    // ------------------------------------------------------------
+
+    // 20. Get the with input and select section
+    const withInputSection = page.getByText("With Input and Select", { exact: true }).locator("..");
+
+    // 21. Verify 'Grid' is selected by default
+    const gridButton = withInputSection.getByRole("button", { name: "Grid view" });
+    await expect(gridButton).toHaveAttribute("aria-pressed", "true");
+
+    // 22. Click on 'List'
+    const listButton = withInputSection.getByRole("button", { name: "List view" });
+    await listButton.hover();
+    await page.waitForTimeout(300);
+    await listButton.click();
+
+    // 23. Verify 'List' is now selected
+    await expect(listButton).toHaveAttribute("aria-pressed", "true");
+    await expect(gridButton).toHaveAttribute("aria-pressed", "false");
+
+    // 24. Verify the search input is present
+    await expect(withInputSection.getByRole("searchbox", { name: "Search..." })).toBeVisible();
+
+    // ------------------------------------------------------------
+    // Vertical Example
+    // ------------------------------------------------------------
+
+    // 25. Get the vertical section
+    const verticalSection = page.getByText("Vertical", { exact: true }).first().locator("..");
+
+    // 26. Click the bold toggle in vertical layout
+    const verticalBold = verticalSection.getByRole("button", { name: "Toggle bold" });
+    await verticalBold.hover();
+    await page.waitForTimeout(300);
+    await verticalBold.click();
+
+    // 27. Verify it's pressed
+    await expect(verticalBold).toHaveAttribute("aria-pressed", "true");
+
+    // ------------------------------------------------------------
+    // Vertical Outline Example
+    // ------------------------------------------------------------
+
+    // 28. Get the vertical outline section
+    const verticalOutlineSection = page
+      .getByText("Vertical Outline", { exact: true })
+      .locator("..");
+
+    // 29. Verify 'All' is selected by default
+    const verticalAllButton = verticalOutlineSection.getByRole("button", { name: "Toggle all" });
+    await expect(verticalAllButton).toHaveAttribute("aria-pressed", "true");
+
+    // ------------------------------------------------------------
+    // Docs Page Test - Toggle to Docs and Scroll
+    // ------------------------------------------------------------
+
+    // 30. Click the toggle button to switch to docs view
+    await page.getByRole("button", { name: "Toggle between preview and docs" }).click();
+
+    // 31. Verify the docs page is visible by checking for the main heading
+    await expect(page.getByRole("heading", { name: "Toggle Group", level: 1 })).toBeVisible();
+
+    // 32. Verify the Installation section is present
+    await expect(page.getByRole("heading", { name: "Installation", level: 2 })).toBeVisible();
+
+    // 33. Verify the Usage section is present
+    await expect(page.getByRole("heading", { name: "Usage", level: 2 })).toBeVisible();
+
+    // 34. Verify the Examples section is present
+    await expect(page.getByRole("heading", { name: "Examples", level: 2 })).toBeVisible();
+
+    // 35. Scroll to the bottom of the page to see all examples
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+    await page.waitForTimeout(500);
+
+    // 36. Verify the API Reference section is present
+    await expect(page.getByRole("heading", { name: "API Reference", level: 2 })).toBeVisible();
+  });
+});

--- a/tests/toggle.spec.ts
+++ b/tests/toggle.spec.ts
@@ -1,0 +1,143 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Toggle Examples", () => {
+  test("examples", async ({ page }) => {
+    await page.goto("http://localhost:5181/ui/toggle");
+
+    await page.waitForLoadState("networkidle");
+
+    // ------------------------------------------------------------
+    // Basic Example
+    // ------------------------------------------------------------
+
+    // 1. Get the basic section
+    const basicSection = page.getByText("Basic", { exact: true }).locator("..");
+
+    // 2. Verify the bold toggle is pressed by default
+    const boldToggle = basicSection.getByRole("button", { name: "Toggle bold" });
+    await expect(boldToggle).toHaveAttribute("aria-pressed", "true");
+
+    // 3. Click the italic toggle
+    const italicToggle = basicSection.getByRole("button", { name: "Toggle italic" });
+    await italicToggle.hover();
+    await page.waitForTimeout(300);
+    await italicToggle.click();
+
+    // 4. Verify italic toggle is now pressed
+    await expect(italicToggle).toHaveAttribute("aria-pressed", "true");
+
+    // 5. Click the underline toggle
+    const underlineToggle = basicSection.getByRole("button", { name: "Toggle underline" });
+    await underlineToggle.hover();
+    await page.waitForTimeout(300);
+    await underlineToggle.click();
+
+    // 6. Verify underline toggle is now pressed
+    await expect(underlineToggle).toHaveAttribute("aria-pressed", "true");
+
+    // ------------------------------------------------------------
+    // Outline Example
+    // ------------------------------------------------------------
+
+    // 7. Get the outline section
+    const outlineSection = page.getByText("Outline", { exact: true }).locator("..");
+
+    // 8. Click the italic outline toggle
+    const italicOutline = outlineSection.getByRole("button", { name: "Toggle italic" });
+    await italicOutline.hover();
+    await page.waitForTimeout(300);
+    await italicOutline.click();
+
+    // 9. Verify italic outline toggle is pressed
+    await expect(italicOutline).toHaveAttribute("aria-pressed", "true");
+
+    // ------------------------------------------------------------
+    // Sizes Example
+    // ------------------------------------------------------------
+
+    // 10. Get the sizes section
+    const sizesSection = page.getByText("Sizes", { exact: true }).locator("..");
+
+    // 11. Verify all size buttons are visible
+    await expect(sizesSection.getByRole("button", { name: "Toggle small" })).toBeVisible();
+    await expect(sizesSection.getByRole("button", { name: "Toggle default" })).toBeVisible();
+    await expect(sizesSection.getByRole("button", { name: "Toggle large" })).toBeVisible();
+
+    // 12. Click the small toggle
+    const smallToggle = sizesSection.getByRole("button", { name: "Toggle small" });
+    await smallToggle.hover();
+    await page.waitForTimeout(300);
+    await smallToggle.click();
+
+    // 13. Verify small toggle is pressed
+    await expect(smallToggle).toHaveAttribute("aria-pressed", "true");
+
+    // ------------------------------------------------------------
+    // Disabled Example
+    // ------------------------------------------------------------
+
+    // 14. Get the disabled section
+    const disabledSection = page.getByText("Disabled", { exact: true }).locator("..");
+
+    // 15. Verify disabled buttons are present and disabled
+    const disabledToggle = disabledSection.getByRole("button", {
+      name: "Toggle disabled",
+      exact: true,
+    });
+    await expect(disabledToggle).toBeDisabled();
+
+    const disabledOutline = disabledSection.getByRole("button", {
+      name: "Toggle disabled outline",
+      exact: true,
+    });
+    await expect(disabledOutline).toBeDisabled();
+
+    // ------------------------------------------------------------
+    // With Icon Example
+    // ------------------------------------------------------------
+
+    // 16. Get the with icon section
+    const withIconSection = page.getByText("With Icon", { exact: true }).locator("..");
+
+    // 17. Verify the bookmark toggle is pressed by default
+    const bookmarkToggle = withIconSection.getByRole("button", {
+      name: "Toggle bookmark",
+      exact: true,
+    });
+    await expect(bookmarkToggle).toHaveAttribute("aria-pressed", "true");
+
+    // 18. Click to unpressed
+    await bookmarkToggle.hover();
+    await page.waitForTimeout(300);
+    await bookmarkToggle.click();
+
+    // 19. Verify it's now unpressed
+    await expect(bookmarkToggle).toHaveAttribute("aria-pressed", "false");
+
+    // ------------------------------------------------------------
+    // Docs Page Test - Toggle to Docs and Scroll
+    // ------------------------------------------------------------
+
+    // 20. Click the toggle button to switch to docs view
+    await page.getByRole("button", { name: "Toggle between preview and docs" }).click();
+
+    // 21. Verify the docs page is visible by checking for the main heading
+    await expect(page.getByRole("heading", { name: "Toggle", level: 1 })).toBeVisible();
+
+    // 22. Verify the Installation section is present
+    await expect(page.getByRole("heading", { name: "Installation", level: 2 })).toBeVisible();
+
+    // 23. Verify the Usage section is present
+    await expect(page.getByRole("heading", { name: "Usage", level: 2 })).toBeVisible();
+
+    // 24. Verify the Examples section is present
+    await expect(page.getByRole("heading", { name: "Examples", level: 2 })).toBeVisible();
+
+    // 25. Scroll to the bottom of the page to see all examples
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+    await page.waitForTimeout(500);
+
+    // 26. Verify the API Reference section is present
+    await expect(page.getByRole("heading", { name: "API Reference", level: 2 })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

- Sync toggle examples from Shadcn UI with all 8 example variants
- Update toggle-group examples including the "With Input and Select" example
- Create/update MDX documentation for both toggle and toggle-group components
- Add comprehensive Playwright test suites for visual validation

## Files Changed

- `src/registry/examples/toggle-example.tsx` - New toggle examples (8 variants)
- `src/registry/examples/toggle-group-example.tsx` - Updated with "With Input and Select" example
- `src/pages/ui/toggle.mdx` - New toggle documentation
- `src/pages/ui/toggle-group.mdx` - Updated toggle-group documentation with Examples section
- `tests/toggle.spec.ts` - Playwright tests for toggle component
- `tests/toggle-group.spec.ts` - Playwright tests for toggle-group component

## Example Variants

### Toggle
- Basic (with defaultPressed)
- Outline
- Sizes (sm, default, lg)
- With Button Text
- With Button Icon
- With Button Icon + Text
- Disabled
- With Icon

### Toggle Group
- Basic (multiple selection)
- Outline (single selection)
- Outline With Icons
- Sizes
- With Spacing
- With Icons
- Filter
- Date Range
- Sort
- With Input and Select
- Vertical
- Vertical Outline
- Vertical Outline With Icons
- Vertical With Spacing

## Validation

- [x] Type checking passes
- [x] Playwright visual validation completed
- [x] Playwright test suites pass (2/2)

## QA Videos

- [Toggle QA Video](https://okesuto.carere.dev/toggle-qa-video.webm)
- [Toggle Group QA Video](https://okesuto.carere.dev/toggle-group-qa-video.webm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)