### PR TITLE
feat(docs): sync switch examples and documentation

### DIFF
--- a/src/pages/ui/switch.mdx
+++ b/src/pages/ui/switch.mdx
@@ -18,6 +18,12 @@ shadcn@latest add switch
 
 ### Manual
 
+Install the following dependencies:
+
+```package-install
+@kobalte/core
+```
+
 Copy and paste the following code into your project.
 
 ```tsx file=../../registry/ui/switch.tsx showLineNumbers
@@ -32,4 +38,58 @@ import { Switch } from "~/components/ui/switch";
 
 ```tsx showLineNumbers
 <Switch />
+```
+
+## Examples
+
+Here are the source code of all the examples from the preview page:
+
+### Basic
+
+```tsx
+import { Field, FieldLabel } from "~/components/ui/field";
+import { Switch } from "~/components/ui/switch";
+```
+
+```tsx file=../../registry/examples/switch-example.tsx#L17-L26
+
+```
+
+### With Description
+
+```tsx
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldLabel,
+  FieldTitle,
+} from "~/components/ui/field";
+import { Switch } from "~/components/ui/switch";
+```
+
+```tsx file=../../registry/examples/switch-example.tsx#L28-L44
+
+```
+
+### Disabled
+
+```tsx
+import { Label } from "~/components/ui/label";
+import { Switch } from "~/components/ui/switch";
+```
+
+```tsx file=../../registry/examples/switch-example.tsx#L46-L61
+
+```
+
+### Sizes
+
+```tsx
+import { Label } from "~/components/ui/label";
+import { Switch } from "~/components/ui/switch";
+```
+
+```tsx file=../../registry/examples/switch-example.tsx#L63-L78
+
 ```

--- a/src/registry/examples/switch-example.tsx
+++ b/src/registry/examples/switch-example.tsx
@@ -1,6 +1,7 @@
 import { Example, ExampleWrapper } from "@/components/example";
+import { Field, FieldContent, FieldDescription, FieldLabel, FieldTitle } from "@/registry/ui/field";
+import { Label } from "@/registry/ui/label";
 import { Switch } from "@/registry/ui/switch";
-import { Field, FieldContent, FieldDescription, FieldLabel, FieldTitle } from "../ui/field";
 
 export default function SwitchExample() {
   return (
@@ -48,11 +49,11 @@ function SwitchDisabled() {
       <div class="flex flex-col gap-12">
         <div class="flex items-center gap-2">
           <Switch id="switch-disabled-unchecked" disabled />
-          <label for="switch-disabled-unchecked">Disabled (Unchecked)</label>
+          <Label for="switch-disabled-unchecked">Disabled (Unchecked)</Label>
         </div>
         <div class="flex items-center gap-2">
           <Switch id="switch-disabled-checked" defaultChecked disabled />
-          <label for="switch-disabled-checked">Disabled (Checked)</label>
+          <Label for="switch-disabled-checked">Disabled (Checked)</Label>
         </div>
       </div>
     </Example>
@@ -65,11 +66,11 @@ function SwitchSizes() {
       <div class="flex flex-col gap-12">
         <div class="flex items-center gap-2">
           <Switch id="switch-size-sm" size="sm" />
-          <label for="switch-size-sm">Small</label>
+          <Label for="switch-size-sm">Small</Label>
         </div>
         <div class="flex items-center gap-2">
           <Switch id="switch-size-default" size="default" />
-          <label for="switch-size-default">Default</label>
+          <Label for="switch-size-default">Default</Label>
         </div>
       </div>
     </Example>

--- a/tests/switch.spec.ts
+++ b/tests/switch.spec.ts
@@ -1,0 +1,130 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Switch Component", () => {
+  test("examples", async ({ page }) => {
+    await page.goto("/ui/switch");
+
+    // Wait for the page to be ready
+    await page.waitForSelector('[data-slot="switch"]');
+
+    // ------------------------------------------------------------
+    // Basic Example
+    // ------------------------------------------------------------
+
+    // 1. Get the basic section
+    const basicSection = page.getByText("Basic", { exact: true }).locator("..");
+
+    // 2. Verify the switch is present
+    const airplaneModeSwitch = basicSection.getByRole("switch", { name: "Airplane Mode" });
+    await expect(airplaneModeSwitch).toBeVisible();
+
+    // 3. Verify switch is unchecked initially
+    await expect(airplaneModeSwitch).not.toBeChecked();
+
+    // 4. Click the label to toggle it on
+    await basicSection.getByText("Airplane Mode", { exact: true }).click();
+
+    // 5. Wait for 300ms
+    await page.waitForTimeout(300);
+
+    // 6. Verify switch is now checked
+    await expect(airplaneModeSwitch).toBeChecked();
+
+    // 7. Click again to toggle it off
+    await basicSection.getByText("Airplane Mode", { exact: true }).click();
+
+    // 8. Verify switch is unchecked again
+    await expect(airplaneModeSwitch).not.toBeChecked();
+
+    // ------------------------------------------------------------
+    // With Description Example
+    // ------------------------------------------------------------
+
+    // 9. Get the with description section
+    const withDescriptionSection = page
+      .getByText("With Description", { exact: true })
+      .locator("..");
+
+    // 10. Verify the switch is present
+    const shareAcrossDevicesSwitch = withDescriptionSection.getByRole("switch");
+    await expect(shareAcrossDevicesSwitch).toBeVisible();
+
+    // 11. Verify the title is present
+    await expect(withDescriptionSection.getByText("Share across devices")).toBeVisible();
+
+    // 12. Verify the description is present
+    await expect(
+      withDescriptionSection.getByText(
+        "Focus is shared across devices, and turns off when you leave the app.",
+      ),
+    ).toBeVisible();
+
+    // 13. Verify switch is unchecked initially
+    await expect(shareAcrossDevicesSwitch).not.toBeChecked();
+
+    // 14. Click the title text (label) to toggle the switch
+    await withDescriptionSection.getByText("Share across devices", { exact: true }).click();
+
+    // 15. Wait for 300ms
+    await page.waitForTimeout(300);
+
+    // 16. Verify switch is now checked
+    await expect(shareAcrossDevicesSwitch).toBeChecked();
+
+    // ------------------------------------------------------------
+    // Disabled Example
+    // ------------------------------------------------------------
+
+    // 17. Get the disabled section
+    const disabledSection = page.getByText("Disabled", { exact: true }).locator("..");
+
+    // 18. Verify disabled unchecked switch is present and disabled
+    const disabledUncheckedSwitch = disabledSection.getByRole("switch", {
+      name: "Disabled (Unchecked)",
+    });
+    await expect(disabledUncheckedSwitch).toBeVisible();
+    await expect(disabledUncheckedSwitch).toBeDisabled();
+    await expect(disabledUncheckedSwitch).not.toBeChecked();
+
+    // 19. Verify disabled checked switch is present and disabled
+    const disabledCheckedSwitch = disabledSection.getByRole("switch", {
+      name: "Disabled (Checked)",
+    });
+    await expect(disabledCheckedSwitch).toBeVisible();
+    await expect(disabledCheckedSwitch).toBeDisabled();
+    await expect(disabledCheckedSwitch).toBeChecked();
+
+    // ------------------------------------------------------------
+    // Sizes Example
+    // ------------------------------------------------------------
+
+    // 20. Get the sizes section
+    const sizesSection = page.getByText("Sizes", { exact: true }).locator("..");
+
+    // 21. Verify small switch is present
+    const smallSwitch = sizesSection.getByRole("switch", { name: "Small" });
+    await expect(smallSwitch).toBeVisible();
+
+    // 22. Click the small switch label
+    await sizesSection.getByText("Small", { exact: true }).click();
+
+    // 23. Wait for 300ms
+    await page.waitForTimeout(300);
+
+    // 24. Verify small switch is now checked
+    await expect(smallSwitch).toBeChecked();
+
+    // 25. Verify default switch is present
+    const defaultSwitch = sizesSection.getByRole("switch", { name: "Default" });
+    await expect(defaultSwitch).toBeVisible();
+
+    // 26. Click the default switch label
+    await sizesSection.getByText("Default", { exact: true }).click();
+
+    // 27. Wait for 300ms
+    await page.waitForTimeout(300);
+
+    // 28. Verify default switch is now checked
+    await expect(defaultSwitch).toBeChecked();
+  });
+});


### PR DESCRIPTION
## Summary

- Sync examples from Shadcn UI for switch component
- Transform React patterns to SolidJS
- Update/create MDX documentation with Examples section
- Add Playwright test suite for switch component

## Changes

- Updated `src/registry/examples/switch-example.tsx`:
  - Fixed import paths to use proper path aliases
  - Replaced native `<label>` elements with `<Label>` component
  
- Updated `src/pages/ui/switch.mdx`:
  - Added installation dependencies section
  - Added Examples section with code references for all 4 examples

- Added `tests/switch.spec.ts`:
  - Playwright E2E test suite covering all switch examples
  - Tests toggle functionality, disabled states, and size variants

## Validation

- [x] Type checking passes (biome)
- [x] Playwright visual validation completed
- [x] Playwright test suite passes

## Video

[QA Video](https://okesuto.carere.dev/switch-qa-video.webm)

## Files Changed

- `src/registry/examples/switch-example.tsx` - Component examples
- `src/pages/ui/switch.mdx` - Documentation
- `tests/switch.spec.ts` - Playwright test suite