### PR TITLE
feat: Persist view mode in cookie storage

### DIFF
--- a/src/lib/view-context.tsx
+++ b/src/lib/view-context.tsx
@@ -1,10 +1,5 @@
-import {
-  type Accessor,
-  createContext,
-  createSignal,
-  type ParentComponent,
-  useContext,
-} from "solid-js";
+import { cookieStorage, makePersisted, messageSync } from "@solid-primitives/storage";
+import { type Accessor, createContext, createSignal, type ParentProps, useContext } from "solid-js";
 import type { View } from "@/lib/types";
 
 type ViewContextProps = {
@@ -23,8 +18,18 @@ export function useView() {
   return context;
 }
 
-export const ViewProvider: ParentComponent = (props) => {
-  const [view, setView] = createSignal<View>("preview");
+type ViewProviderProps = ParentProps<{
+  initialView?: View;
+}>;
+
+export const ViewProvider = (props: ViewProviderProps) => {
+  const [view, setView] = makePersisted(createSignal<View>(props.initialView || "preview"), {
+    name: "zaidan-view",
+    storage: cookieStorage.withOptions({
+      expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000), // 30 days
+    }),
+    sync: messageSync(new BroadcastChannel("zaidan-view")),
+  });
 
   const toggleView = () => {
     setView(view() === "preview" ? "docs" : "preview");

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -7,7 +7,7 @@ import { Suspense } from "solid-js";
 import { HydrationScript } from "solid-js/web";
 import { Shell } from "@/components/shell";
 import { StyleProvider } from "@/lib/style-context";
-import type { Style } from "@/lib/types";
+import type { Style, View } from "@/lib/types";
 import { ViewProvider } from "@/lib/view-context";
 import styleCss from "../styles.css?url";
 
@@ -43,9 +43,20 @@ const getStyleCookie = createIsomorphicFn()
     return "vega";
   });
 
+const getViewCookie = createIsomorphicFn()
+  .server((): View => {
+    const viewCookie = getCookie("zaidan-view");
+    return (viewCookie as View) || "preview";
+  })
+  .client((): View => {
+    // On client, the cookie will be read by the storage manager
+    return "preview";
+  });
+
 function RootComponent() {
   const storageManager = cookieStorageManagerSSR(getServerCookies());
   const initialStyle = getStyleCookie();
+  const initialView = getViewCookie();
   return (
     <html lang="en">
       <head>
@@ -58,7 +69,7 @@ function RootComponent() {
         <ColorModeScript storageType={storageManager.type} />
         <ColorModeProvider storageManager={storageManager}>
           <StyleProvider initialStyle={initialStyle}>
-            <ViewProvider>
+            <ViewProvider initialView={initialView}>
               <Suspense>
                 <Shell />
                 <TanStackRouterDevtools />


### PR DESCRIPTION
## Summary
- Implements cookie-based persistence for view mode (preview/docs)
- Ensures view preference is maintained across page refreshes
- Enables cross-tab synchronization via BroadcastChannel

## Test plan
- [x] Verify view mode changes when using ViewSwitcher
- [x] Verify view mode persists after page refresh
- [x] Verify cross-tab synchronization works
- [x] Verify SSR renders correct view mode
- [x] Verify fallback to default view when cookie is absent
- [x] Verify backward compatibility with existing components

🤖 Generated with [Claude Code](https://claude.com/claude-code)