### PR TITLE
feat: Add GitHub link with star count to header

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -90,6 +90,7 @@
     "tablist",
     "tanstack",
     "twoslash",
+    "UNGH",
     "vaul",
     "velite",
     "vinxi",

--- a/src/components/github-link.tsx
+++ b/src/components/github-link.tsx
@@ -1,4 +1,3 @@
-import { Github } from "lucide-solid";
 import { type ComponentProps, createSignal, onMount, splitProps } from "solid-js";
 import { cn } from "@/lib/utils";
 import { Button } from "@/registry/ui/button";
@@ -58,7 +57,15 @@ export function GitHubLink(props: GitHubLinkProps) {
       {...others}
     >
       <span class="sr-only">View Zaidan on GitHub</span>
-      <Github class="size-4" />
+      <svg
+        role="img"
+        class="size-4 fill-foreground"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <title>GitHub</title>
+        <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+      </svg>
       <span class="font-medium text-xs tabular-nums">{formatStarCount()}</span>
     </Button>
   );

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -39,8 +39,9 @@ export function Shell() {
           <ItemPicker />
         </div>
         <div class="ml-auto flex items-center gap-2 sm:ml-0 md:justify-end xl:ml-auto xl:w-1/3">
-          <ViewSwitcher />
           <GitHubLink />
+          <Separator orientation="vertical" />
+          <ViewSwitcher />
           <Separator orientation="vertical" />
           <SiteConfig class="hidden xl:flex" onClick={() => switchLayout(!isFullLayout())} />
           <Separator orientation="vertical" class="hidden xl:flex" />


### PR DESCRIPTION
## Summary
- Adds a GitHub button to the header that displays the repository's star count
- Positioned next to the ViewSwitcher for easy access
- Fetches live star count from ungh.cc API
- Includes fallback handling for loading and error states
- Implements star count beautification (e.g., 1.2k)

## Implementation Details
- **New component**: `src/components/github-link.tsx`
- **Modified**: `src/components/shell.tsx` (added GitHubLink import and component)
- **API**: Uses ungh.cc for star count (no auth required)
- **Styling**: Matches existing header controls (ghost button, size-8)
- **Accessibility**: Includes screen reader text and proper external link attributes

## Visual Changes
The GitHub button appears between the ViewSwitcher and the first separator in the header, showing the GitHub icon and current star count.

## Test Plan
- [x] Button renders correctly in header
- [x] Star count fetches and displays
- [x] Clicking opens repo in new tab
- [x] Fallback works when API fails
- [x] Works in light and dark mode
- [x] Responsive on mobile devices
- [x] Accessible via keyboard and screen readers

🤖 Generated with [Claude Code](https://claude.com/claude-code)