### PR TITLE
feat: implement command dialog item picker with Cmd+K shortcut

### DIFF
--- a/src/components/item-picker.tsx
+++ b/src/components/item-picker.tsx
@@ -1,4 +1,4 @@
-import { Link, useLocation } from "@tanstack/solid-router";
+import { Link, useLocation, useNavigate } from "@tanstack/solid-router";
 import { docs, ui } from "@velite";
 import {
   type ComponentProps,
@@ -48,6 +48,7 @@ export function ItemPicker(props: ComponentProps<"div">) {
   const [open, setOpen] = createSignal(false);
   const [currentPage, setCurrentPage] = createSignal("Home");
   const location = useLocation();
+  const navigate = useNavigate();
 
   // Keyboard shortcut: Cmd+K / Ctrl+K to open dialog
   createEffect(() => {
@@ -122,7 +123,13 @@ export function ItemPicker(props: ComponentProps<"div">) {
                   <CommandGroup heading={entry.title}>
                     <For each={entry.items}>
                       {(item) => (
-                        <CommandItem value={item.title} onSelect={() => setOpen(false)}>
+                        <CommandItem
+                          value={item.title}
+                          onSelect={() => {
+                            navigate({ to: entry.route, params: { slug: item.slug } });
+                            setOpen(false);
+                          }}
+                        >
                           <Link
                             to={entry.route}
                             params={{ slug: item.slug }}


### PR DESCRIPTION
## Summary
- Replace simple input with button-triggered command dialog showing current page name + ⌘K kbd suffix
- Add global Cmd+K / Ctrl+K keyboard shortcut to open dialog from anywhere
- Implement SSR-safe current page detection using hybrid approach (active link query + pathname fallback)

## Technical Details
- **Component Architecture**: Button trigger + CommandDialog with searchable grouped list
- **Keyboard Shortcut**: createEffect with addEventListener + proper onCleanup
- **Current Page Detection**: 
  - Primary: Query `[data-status="active"]` for TanStack Router's active link
  - Fallback: Parse `window.location.pathname` for edge cases
- **Navigation**: Link components inside CommandItem for proper routing
- **Groups**: "Getting Started" (docs) and "UI" (sorted alphabetically)
- **SSR Safety**: All browser API access (window, document) wrapped in createEffect

## Test Plan
- [ ] Button displays "Home" on homepage
- [ ] Button updates to show current page name after navigation
- [ ] Kbd shows ⌘K
- [ ] Button click opens dialog
- [ ] Cmd+K / Ctrl+K opens dialog
- [ ] Search filters items in real-time
- [ ] Click item navigates and closes dialog
- [ ] Arrow keys + Enter for keyboard navigation
- [ ] Escape closes dialog
- [ ] No SSR errors in console
- [ ] Works on mobile viewport

🤖 Generated with [Claude Code](https://claude.ai/code)