### PR TITLE
Add not found pages and loading skeletons (Vibe Kanban)

### DIFF
--- a/src/routes/_website.ui.{-$slug}.tsx
+++ b/src/routes/_website.ui.{-$slug}.tsx
@@ -5,6 +5,8 @@ import { sharedComponents } from "@/components/mdx-components";
 import { Preview } from "@/components/preview";
 import { TableOfContents } from "@/components/toc";
 import { useView } from "@/lib/view-context";
+import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from "@/registry/ui/empty";
+import { Skeleton } from "@/registry/ui/skeleton";
 
 export const Route = createFileRoute("/_website/ui/{-$slug}")({
   loader: ({ params }) => {
@@ -19,9 +21,17 @@ export const Route = createFileRoute("/_website/ui/{-$slug}")({
     return doc;
   },
   component: RouteComponent,
-  notFoundComponent: (props) => {
-    return <div>Component not found: {(props.data as { slug: string }).slug}</div>;
-  },
+  notFoundComponent: (props) => (
+    <Empty>
+      <EmptyHeader>
+        <EmptyTitle>Component not found</EmptyTitle>
+        <EmptyDescription>
+          The component "{(props.data as { slug: string }).slug}" doesn't exist or couldn't be
+          loaded.
+        </EmptyDescription>
+      </EmptyHeader>
+    </Empty>
+  ),
 });
 
 function RouteComponent() {
@@ -39,7 +49,7 @@ function RouteComponent() {
               class="no-scrollbar min-w-0 flex-1 overflow-y-auto scroll-smooth sm:px-20"
               id="ui-doc"
             >
-              <Suspense fallback={<div>Skeleton ui docs page</div>}>
+              <Suspense fallback={<Skeleton class="h-64 w-full" />}>
                 <MDXContent components={sharedComponents} />
               </Suspense>
             </div>

--- a/src/routes/_website.{-$slug}.tsx
+++ b/src/routes/_website.{-$slug}.tsx
@@ -3,6 +3,8 @@ import { docs } from "@velite";
 import { lazy, Suspense } from "solid-js";
 import { sharedComponents } from "@/components/mdx-components";
 import { TableOfContents } from "@/components/toc";
+import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from "@/registry/ui/empty";
+import { Skeleton } from "@/registry/ui/skeleton";
 
 export const Route = createFileRoute("/_website/{-$slug}")({
   loader: async ({ params }) => {
@@ -18,7 +20,16 @@ export const Route = createFileRoute("/_website/{-$slug}")({
     return doc;
   },
   component: RouteComponent,
-  notFoundComponent: (props) => <div>Doc not found: {(props.data as { slug: string }).slug}</div>,
+  notFoundComponent: (props) => (
+    <Empty>
+      <EmptyHeader>
+        <EmptyTitle>Page not found</EmptyTitle>
+        <EmptyDescription>
+          The page "{(props.data as { slug: string }).slug}" doesn't exist or couldn't be loaded.
+        </EmptyDescription>
+      </EmptyHeader>
+    </Empty>
+  ),
 });
 
 function RouteComponent() {
@@ -28,7 +39,7 @@ function RouteComponent() {
   return (
     <div class="relative mx-auto flex max-w-5xl flex-1 gap-8 overflow-hidden overflow-y-auto p-6">
       <div class="min-w-0 flex-1 overflow-y-auto">
-        <Suspense fallback={<div>Skeleton docs page</div>}>
+        <Suspense fallback={<Skeleton class="h-64 w-full" />}>
           <MDXContent components={sharedComponents} />
         </Suspense>
       </div>

--- a/src/routes/preview.$primitive.$slug.tsx
+++ b/src/routes/preview.$primitive.$slug.tsx
@@ -1,9 +1,20 @@
-import { createFileRoute } from "@tanstack/solid-router";
-import { lazy } from "solid-js";
+import { createFileRoute, notFound } from "@tanstack/solid-router";
+import { ui } from "@velite";
+import { lazy, Suspense } from "solid-js";
+import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from "@/registry/ui/empty";
+import { Skeleton } from "@/registry/ui/skeleton";
 
 export const Route = createFileRoute("/preview/$primitive/$slug")({
   loader: ({ params }) => {
     const { slug, primitive } = params;
+    const component = ui.find((u) => u.slug === slug);
+    if (!component) {
+      throw notFound({
+        data: {
+          slug,
+        },
+      });
+    }
 
     return {
       slug,
@@ -11,12 +22,26 @@ export const Route = createFileRoute("/preview/$primitive/$slug")({
     };
   },
   component: PreviewComponent,
-  notFoundComponent: () => <div>Component not found when rendering iframe</div>,
+  notFoundComponent: (props) => (
+    <Empty>
+      <EmptyHeader>
+        <EmptyTitle>Component not found</EmptyTitle>
+        <EmptyDescription>
+          The component "{(props.data as { slug: string }).slug}" doesn't exist or couldn't be
+          loaded.
+        </EmptyDescription>
+      </EmptyHeader>
+    </Empty>
+  ),
 });
 
 function PreviewComponent() {
   const data = Route.useLoaderData();
   const ExampleComponent = lazy(() => import(`../registry/examples/${data().slug}-example.tsx`));
 
-  return <ExampleComponent />;
+  return (
+    <Suspense fallback={<Skeleton class="h-full w-full" />}>
+      <ExampleComponent />
+    </Suspense>
+  );
 }


### PR DESCRIPTION
## Summary

This PR improves the user experience when navigating to non-existent pages or components by replacing placeholder text with proper styled "not found" pages using the `Empty` component from the registry. It also adds loading skeletons wrapped in Suspense boundaries for better perceived performance during lazy loading.

## Changes Made

### Not Found Pages
- **`preview.$primitive.$slug.tsx`**: Added proper validation in the loader to check if the component exists in the `ui` registry before attempting to render, preventing server crashes on invalid slugs
- **`_website.ui.{-$slug}.tsx`**: Updated `notFoundComponent` to display a styled "Component not found" message
- **`_website.{-$slug}.tsx`**: Updated `notFoundComponent` to display a styled "Page not found" message

### Loading Skeletons
Added `Suspense` boundaries with `Skeleton` fallbacks around lazy-loaded content:
- Preview route: Full-size skeleton (`h-full w-full`)
- UI docs route: Content-sized skeleton (`h-64 w-full`)
- Docs route: Content-sized skeleton (`h-64 w-full`)

## Implementation Details

- Uses the existing `Empty`, `EmptyHeader`, `EmptyTitle`, and `EmptyDescription` components from the registry for consistent styling
- Uses the existing `Skeleton` component from the registry for loading states
- The preview route now validates component slugs against the `ui` collection from Velite before rendering, throwing `notFound()` for invalid slugs
- All not found pages display the requested slug in the error message for better debugging

## Testing

Validated with Playwright:
- `/ui/nonexistent` → Shows "Component not found" message
- `/nonexistent` → Shows "Page not found" message  
- `/preview/ui/nonexistent-component` → Shows "Component not found" message
- Valid routes continue to work correctly with skeleton loading states

---

This PR was written using [Vibe Kanban](https://vibekanban.com)