### PR TITLE
feat(preview): Add dynamic theme CSS variable injection for preview iframe (Vibe Kanban)

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -89,6 +89,7 @@ export const THEMES: { name: Theme; label: string; color: string }[] = [
  * Available radius options with their metadata
  */
 export const RADII: { name: Radius; label: string; value: string }[] = [
+  { name: "default", label: "Default", value: "0.625rem" },
   { name: "none", label: "None", value: "0" },
   { name: "small", label: "Small", value: "0.25rem" },
   { name: "medium", label: "Medium", value: "0.5rem" },

--- a/src/lib/theme-utils.ts
+++ b/src/lib/theme-utils.ts
@@ -1,0 +1,96 @@
+import { RADII } from "@/lib/config";
+import { THEMES_VARIANTS, type ThemeVariant } from "@/lib/themes";
+import type { BaseColor, MenuAccent, Radius, Theme } from "@/lib/types";
+
+/**
+ * Represents a registry theme with CSS variables for light and dark modes
+ */
+export type RegistryTheme = {
+  name: string;
+  cssVars: {
+    light: Record<string, string>;
+    dark: Record<string, string>;
+  };
+};
+
+/**
+ * Find a base color theme variant by name
+ * @param name - The base color name to search for
+ * @returns The matching ThemeVariant or undefined if not found
+ */
+export function getBaseColor(name: BaseColor): ThemeVariant | undefined {
+  return THEMES_VARIANTS.find((theme) => theme.name === name);
+}
+
+/**
+ * Find a theme variant by name
+ * @param name - The theme name to search for
+ * @returns The matching ThemeVariant or undefined if not found
+ */
+export function getTheme(name: Theme): ThemeVariant | undefined {
+  return THEMES_VARIANTS.find((theme) => theme.name === name);
+}
+
+/**
+ * Build a registry theme from design system configuration.
+ * Merges base color and theme CSS variables and applies transformations.
+ *
+ * @param config - The design system configuration
+ * @param config.baseColor - The base color (neutral, stone, zinc, gray)
+ * @param config.theme - The theme color (blue, green, etc.)
+ * @param config.menuAccent - The menu accent style (subtle, bold)
+ * @param config.radius - The border radius setting (default, none, small, medium, large)
+ * @returns The merged RegistryTheme or null if base color or theme is not found
+ */
+export function buildRegistryTheme(config: {
+  baseColor: BaseColor;
+  theme: Theme;
+  menuAccent: MenuAccent;
+  radius: Radius;
+}): RegistryTheme | null {
+  const baseColor = getBaseColor(config.baseColor);
+  const theme = getTheme(config.theme);
+
+  if (!baseColor || !theme) {
+    return null;
+  }
+
+  // Merge base color and theme CSS vars
+  const lightVars: Record<string, string> = {
+    ...(baseColor.cssVars?.light as Record<string, string>),
+    ...(theme.cssVars?.light as Record<string, string>),
+  };
+  const darkVars: Record<string, string> = {
+    ...(baseColor.cssVars?.dark as Record<string, string>),
+    ...(theme.cssVars?.dark as Record<string, string>),
+  };
+
+  // Apply menu accent transformation
+  if (config.menuAccent === "bold") {
+    lightVars.accent = lightVars.primary;
+    lightVars["accent-foreground"] = lightVars["primary-foreground"];
+    darkVars.accent = darkVars.primary;
+    darkVars["accent-foreground"] = darkVars["primary-foreground"];
+    lightVars["sidebar-accent"] = lightVars.primary;
+    lightVars["sidebar-accent-foreground"] = lightVars["primary-foreground"];
+    darkVars["sidebar-accent"] = darkVars.primary;
+    darkVars["sidebar-accent-foreground"] = darkVars["primary-foreground"];
+  }
+
+  // Apply radius transformation
+  if (config.radius && config.radius !== "default") {
+    const radius = RADII.find((r) => r.name === config.radius);
+    if (radius?.value) {
+      lightVars.radius = radius.value;
+      darkVars.radius = radius.value;
+    }
+  }
+
+  return {
+    name: `${config.baseColor}-${config.theme}`,
+    cssVars: {
+      light: lightVars,
+      dark: darkVars,
+    },
+  };
+}


### PR DESCRIPTION
## Summary

This PR implements dynamic theme, baseColor, and menuAccent URL parameter handling in the preview page, enabling real-time theme customization within the component preview iframe. This ports the Shadcn v4 design system provider logic to SolidJS.

## Changes Made

### New Files
- **`src/lib/theme-utils.ts`** - Theme utility functions:
  - `getBaseColor()` - Finds a base color theme variant by name
  - `getTheme()` - Finds a theme variant by name
  - `buildRegistryTheme()` - Merges base color and theme CSS variables with menu accent and radius transformations
  - `RegistryTheme` type definition

### Modified Files
- **`src/lib/config.ts`** - Added missing "default" radius option to RADII array with value "0.625rem"
- **`src/routes/preview.$primitive.$slug.tsx`** - Added theme handling:
  - `registryTheme` memo for reactive theme computation
  - Effect to inject CSS variables into a `<style>` element in document head
  - Effect to apply base color class to document.body
  - Cleanup logic to remove style element on unmount

## Why These Changes Were Made

The preview iframe needed to support dynamic theming based on URL parameters (`theme`, `baseColor`, `menuAccent`, `radius`) to allow users to see component previews with different design system configurations. This mirrors the behavior in Shadcn v4's customizer.

## Implementation Details

### Theme Merging Strategy
- Base colors (neutral, stone, zinc, gray) define the FULL set of CSS variables
- Theme colors (amber, blue, etc.) only define accent-related variables
- Theme colors are merged ON TOP of base colors, inheriting undefined variables

### Menu Accent Transformation
When `menuAccent === "bold"`:
- `accent` and `accent-foreground` use primary colors
- `sidebar-accent` and `sidebar-accent-foreground` use primary colors

### CSS Variable Injection
CSS variables are injected into a `<style id="design-system-theme-vars">` element with separate `:root` (light) and `.dark` selectors.

## Testing

- ✅ TypeScript type checking passes
- ✅ Biome linting passes
- ✅ Pre-commit hooks pass

---

This PR was written using [Vibe Kanban](https://vibekanban.com)