### PR TITLE
feat(customizer): implement random, reset, and lock mechanisms for pickers (Vibe Kanban)

### DIFF
--- a/src/components/customizer.tsx
+++ b/src/components/customizer.tsx
@@ -11,43 +11,46 @@ import StylePicker from "@/components/pickers/style-picker";
 import ThemePicker from "@/components/pickers/theme-picker";
 import { RandomButton } from "@/components/random-button";
 import { ResetButton } from "@/components/reset-button";
+import { LocksProvider } from "@/lib/use-locks";
 import { cn } from "@/lib/utils";
 import { FieldGroup } from "@/registry/ui/field";
 
 export function Customizer(props: ComponentProps<"div">) {
   return (
-    <div
-      data-slot="customizer"
-      class={cn("no-scrollbar flex flex-col overflow-y-auto md:w-48", props.class)}
-    >
-      <div class="hidden items-center gap-2 px-[calc(--spacing(2.5))] pb-1 md:flex md:flex-col md:items-start">
-        <Settings2Icon class="size-4" strokeWidth={2} />
-        <div class="relative flex flex-col gap-1 rounded-lg text-[13px]/snug">
-          <div class="flex items-center gap-1 text-balance font-medium">
-            Build your own shadcn/ui
-          </div>
-          <div class="hidden md:flex">
-            When you&apos;re done, click Create Project to start a new project.
+    <LocksProvider>
+      <div
+        data-slot="customizer"
+        class={cn("no-scrollbar flex flex-col overflow-y-auto md:w-48", props.class)}
+      >
+        <div class="hidden items-center gap-2 px-[calc(--spacing(2.5))] pb-1 md:flex md:flex-col md:items-start">
+          <Settings2Icon class="size-4" strokeWidth={2} />
+          <div class="relative flex flex-col gap-1 rounded-lg text-[13px]/snug">
+            <div class="flex items-center gap-1 text-balance font-medium">
+              Build your own shadcn/ui
+            </div>
+            <div class="hidden md:flex">
+              When you&apos;re done, click Create Project to start a new project.
+            </div>
           </div>
         </div>
+        <div class="no-scrollbar h-15 overflow-x-auto overflow-y-hidden md:h-full md:overflow-y-auto md:overflow-x-hidden">
+          <FieldGroup class="flex h-full flex-1 flex-row gap-2 md:flex-col md:gap-0">
+            <BasePicker />
+            <StylePicker />
+            <BaseColorPicker />
+            <ThemePicker />
+            <IconLibraryPicker />
+            <FontPicker />
+            <RadiusPicker />
+            <MenuColorPicker />
+            <MenuAccentPicker />
+            <div class="mt-auto hidden w-full flex-col items-center gap-0 md:flex">
+              <RandomButton />
+              <ResetButton />
+            </div>
+          </FieldGroup>
+        </div>
       </div>
-      <div class="no-scrollbar h-15 overflow-x-auto overflow-y-hidden md:h-full md:overflow-y-auto md:overflow-x-hidden">
-        <FieldGroup class="flex h-full flex-1 flex-row gap-2 md:flex-col md:gap-0">
-          <BasePicker />
-          <StylePicker />
-          <BaseColorPicker />
-          <ThemePicker />
-          <IconLibraryPicker />
-          <FontPicker />
-          <RadiusPicker />
-          <MenuColorPicker />
-          <MenuAccentPicker />
-          <div class="mt-auto hidden w-full flex-col items-center gap-0 md:flex">
-            <RandomButton />
-            <ResetButton />
-          </div>
-        </FieldGroup>
-      </div>
-    </div>
+    </LocksProvider>
   );
 }

--- a/src/components/lock-button.tsx
+++ b/src/components/lock-button.tsx
@@ -1,0 +1,32 @@
+import { Lock, LockOpen } from "lucide-solid";
+import type { LockableParam } from "@/lib/types";
+import { useLocks } from "@/lib/use-locks";
+import { cn } from "@/lib/utils";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/registry/ui/tooltip";
+
+export function LockButton(props: { param: LockableParam; class?: string }) {
+  const { isLocked, toggleLock } = useLocks();
+
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        as="button"
+        type="button"
+        onClick={() => toggleLock(props.param)}
+        data-locked={isLocked(props.param)}
+        class={cn(
+          "flex pointer-coarse:hidden size-4 cursor-pointer items-center justify-center rounded opacity-0 transition-opacity focus:opacity-100 group-focus-within/picker:opacity-100 group-hover/picker:opacity-100 data-[locked=true]:opacity-100",
+          props.class,
+        )}
+        aria-label={isLocked(props.param) ? "Unlock" : "Lock"}
+      >
+        {isLocked(props.param) ? (
+          <Lock strokeWidth={2} class="size-4 text-foreground" />
+        ) : (
+          <LockOpen strokeWidth={2} class="size-4 text-foreground" />
+        )}
+      </TooltipTrigger>
+      <TooltipContent>{isLocked(props.param) ? "Unlock" : "Lock"}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/src/components/pickers/base-color-picker.tsx
+++ b/src/components/pickers/base-color-picker.tsx
@@ -1,5 +1,6 @@
 import { useLocation, useNavigate } from "@tanstack/solid-router";
 import { For } from "solid-js";
+import { LockButton } from "@/components/lock-button";
 import { useColorMode } from "@/lib/color-mode";
 import { BASE_COLORS, DEFAULT_CONFIG } from "@/lib/config";
 import type { BaseColor } from "@/lib/types";
@@ -77,6 +78,7 @@ export default function BaseColorPicker() {
           </DropdownMenuGroup>
         </DropdownMenuContent>
       </DropdownMenu>
+      <LockButton param="baseColor" class="absolute top-1/2 right-10 -translate-y-1/2" />
     </div>
   );
 }

--- a/src/components/pickers/font-picker.tsx
+++ b/src/components/pickers/font-picker.tsx
@@ -1,5 +1,6 @@
 import { useLocation, useNavigate } from "@tanstack/solid-router";
 import { For, Show } from "solid-js";
+import { LockButton } from "@/components/lock-button";
 import { DEFAULT_CONFIG, FONTS } from "@/lib/config";
 import type { Font } from "@/lib/types";
 import { useIsMobile } from "@/registry/hooks/use-mobile";
@@ -69,6 +70,7 @@ export default function FontPicker() {
           </DropdownMenuRadioGroup>
         </DropdownMenuContent>
       </DropdownMenu>
+      <LockButton param="font" class="absolute top-1/2 right-10 -translate-y-1/2" />
     </div>
   );
 }

--- a/src/components/pickers/menu-accent-picker.tsx
+++ b/src/components/pickers/menu-accent-picker.tsx
@@ -1,6 +1,7 @@
 import { useLocation, useNavigate } from "@tanstack/solid-router";
 import { PaintBucket } from "lucide-solid";
 import { For } from "solid-js";
+import { LockButton } from "@/components/lock-button";
 import { DEFAULT_CONFIG, MENU_ACCENTS } from "@/lib/config";
 import type { MenuAccent } from "@/lib/types";
 import { useIsMobile } from "@/registry/hooks/use-mobile";
@@ -52,6 +53,7 @@ export default function MenuAccentPicker() {
           </DropdownMenuRadioGroup>
         </DropdownMenuContent>
       </DropdownMenu>
+      <LockButton param="menuAccent" class="absolute top-1/2 right-10 -translate-y-1/2" />
     </div>
   );
 }

--- a/src/components/pickers/radius-picker.tsx
+++ b/src/components/pickers/radius-picker.tsx
@@ -1,6 +1,7 @@
 import { useLocation, useNavigate } from "@tanstack/solid-router";
 import { For } from "solid-js";
 import { Radius as RadiusIcon } from "@/components/icons/radius";
+import { LockButton } from "@/components/lock-button";
 import { DEFAULT_CONFIG, RADII } from "@/lib/config";
 import type { Radius } from "@/lib/types";
 import { useIsMobile } from "@/registry/hooks/use-mobile";
@@ -63,6 +64,7 @@ export default function RadiusPicker() {
           </DropdownMenuRadioGroup>
         </DropdownMenuContent>
       </DropdownMenu>
+      <LockButton param="radius" class="absolute top-1/2 right-10 -translate-y-1/2" />
     </div>
   );
 }

--- a/src/components/pickers/style-picker.tsx
+++ b/src/components/pickers/style-picker.tsx
@@ -6,6 +6,7 @@ import { Maia } from "@/components/icons/maia";
 import { Mira } from "@/components/icons/mira";
 import { Nova } from "@/components/icons/nova";
 import { Vega } from "@/components/icons/vega";
+import { LockButton } from "@/components/lock-button";
 import { DEFAULT_CONFIG, STYLES } from "@/lib/config";
 import type { Style } from "@/lib/types";
 import { useIsMobile } from "@/registry/hooks/use-mobile";
@@ -77,6 +78,7 @@ export default function StylePicker() {
           </DropdownMenuRadioGroup>
         </DropdownMenuContent>
       </DropdownMenu>
+      <LockButton param="style" class="absolute top-1/2 right-10 -translate-y-1/2" />
     </div>
   );
 }

--- a/src/components/pickers/theme-picker.tsx
+++ b/src/components/pickers/theme-picker.tsx
@@ -1,5 +1,6 @@
 import { useLocation, useNavigate } from "@tanstack/solid-router";
 import { For } from "solid-js";
+import { LockButton } from "@/components/lock-button";
 import { BASE_COLORS, DEFAULT_CONFIG, THEMES } from "@/lib/config";
 import type { Theme } from "@/lib/types";
 import { useIsMobile } from "@/registry/hooks/use-mobile";
@@ -97,6 +98,7 @@ export default function ThemePicker() {
           </DropdownMenuRadioGroup>
         </DropdownMenuContent>
       </DropdownMenu>
+      <LockButton param="theme" class="absolute top-1/2 right-10 -translate-y-1/2" />
     </div>
   );
 }

--- a/src/components/random-button.tsx
+++ b/src/components/random-button.tsx
@@ -1,16 +1,78 @@
+import { useLocation, useNavigate } from "@tanstack/solid-router";
 import { Dice5 } from "lucide-solid";
 import { type ComponentProps, onCleanup, onMount } from "solid-js";
+import {
+  BASE_COLORS,
+  DEFAULT_CONFIG,
+  FONTS,
+  MENU_ACCENTS,
+  RADII,
+  STYLES,
+  THEMES,
+} from "@/lib/config";
+import type { BaseColor, Font, MenuAccent, Radius, Style, Theme } from "@/lib/types";
+import { useLocks } from "@/lib/use-locks";
 import { cn } from "@/lib/utils";
 import { Button } from "@/registry/ui/button";
 import { Kbd } from "@/registry/ui/kbd";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/registry/ui/tooltip";
 
-// TODO: Uncomment when implementing randomization feature
-// function randomItem<T>(array: readonly T[]): T {
-//   return array[Math.floor(Math.random() * array.length)];
-// }
+function randomItem<T>(array: readonly T[]): T {
+  return array[Math.floor(Math.random() * array.length)];
+}
 
 export function RandomButton(props: Pick<ComponentProps<"button">, "class">) {
+  const { locks } = useLocks();
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const handleRandomize = () => {
+    const currentLocks = locks();
+    const currentSearch = location().search;
+
+    // Use current value if locked, otherwise randomize
+    const style: Style = currentLocks.has("style")
+      ? (currentSearch.style ?? DEFAULT_CONFIG.style)
+      : randomItem(STYLES).name;
+
+    const baseColor: BaseColor = currentLocks.has("baseColor")
+      ? (currentSearch.baseColor ?? DEFAULT_CONFIG.baseColor)
+      : randomItem(BASE_COLORS).name;
+
+    // Theme can be a base color or a theme color
+    const allThemes = [...THEMES.map((t) => t.name), ...BASE_COLORS.map((c) => c.name)] as Theme[];
+    const theme: Theme = currentLocks.has("theme")
+      ? (currentSearch.theme ?? DEFAULT_CONFIG.theme)
+      : randomItem(allThemes);
+
+    const font: Font = currentLocks.has("font")
+      ? (currentSearch.font ?? DEFAULT_CONFIG.font)
+      : randomItem(FONTS).value;
+
+    // Include "default" radius option
+    const allRadii = ["default", ...RADII.map((r) => r.name)] as Radius[];
+    const radius: Radius = currentLocks.has("radius")
+      ? (currentSearch.radius ?? DEFAULT_CONFIG.radius)
+      : randomItem(allRadii);
+
+    const menuAccent: MenuAccent = currentLocks.has("menuAccent")
+      ? (currentSearch.menuAccent ?? DEFAULT_CONFIG.menuAccent)
+      : randomItem(MENU_ACCENTS).name;
+
+    navigate({
+      to: ".",
+      search: (prev) => ({
+        ...prev,
+        style,
+        baseColor,
+        theme,
+        font,
+        radius,
+        menuAccent,
+      }),
+    });
+  };
+
   onMount(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if ((e.key === "r" || e.key === "R") && !e.metaKey && !e.ctrlKey) {
@@ -23,7 +85,7 @@ export function RandomButton(props: Pick<ComponentProps<"button">, "class">) {
           return;
         }
         e.preventDefault();
-        // TODO: Randomize the design system params + add locks
+        handleRandomize();
       }
     };
 
@@ -37,6 +99,7 @@ export function RandomButton(props: Pick<ComponentProps<"button">, "class">) {
         as={Button}
         variant="ghost"
         size="sm"
+        onClick={handleRandomize}
         class={cn(
           "h-[calc(--spacing(13.5))] w-[140px] touch-manipulation select-none justify-between rounded-xl border border-foreground/10 bg-muted/50 focus-visible:border-transparent focus-visible:ring-1 sm:rounded-lg md:w-full md:rounded-lg md:border-transparent md:bg-transparent md:pr-3.5! md:pl-2! md:hover:bg-muted",
           props.class,

--- a/src/components/reset-button.tsx
+++ b/src/components/reset-button.tsx
@@ -1,4 +1,6 @@
+import { useNavigate } from "@tanstack/solid-router";
 import { Undo2 } from "lucide-solid";
+import { DEFAULT_CONFIG } from "@/lib/config";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -13,6 +15,23 @@ import {
 import { Button } from "@/registry/ui/button";
 
 export function ResetButton() {
+  const navigate = useNavigate();
+
+  const handleReset = () => {
+    navigate({
+      to: ".",
+      search: (prev) => ({
+        ...prev,
+        style: DEFAULT_CONFIG.style,
+        baseColor: DEFAULT_CONFIG.baseColor,
+        theme: DEFAULT_CONFIG.theme,
+        font: DEFAULT_CONFIG.font,
+        radius: DEFAULT_CONFIG.radius,
+        menuAccent: DEFAULT_CONFIG.menuAccent,
+      }),
+    });
+  };
+
   return (
     <AlertDialog>
       <AlertDialogTrigger
@@ -37,7 +56,9 @@ export function ResetButton() {
         </AlertDialogHeader>
         <AlertDialogFooter>
           <AlertDialogCancel class="rounded-lg">Cancel</AlertDialogCancel>
-          <AlertDialogAction class="rounded-lg">Reset</AlertDialogAction>
+          <AlertDialogAction class="rounded-lg" onClick={handleReset}>
+            Reset
+          </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -41,6 +41,8 @@ export type Radius = z.infer<typeof RadiusSchema>;
 export const MenuAccentSchema = z.enum(["subtle", "bold"]);
 export type MenuAccent = z.infer<typeof MenuAccentSchema>;
 
+export type LockableParam = "style" | "baseColor" | "theme" | "font" | "radius" | "menuAccent";
+
 export type TocEntry = docs["toc"];
 
 export type IframeMessage =

--- a/src/lib/use-locks.tsx
+++ b/src/lib/use-locks.tsx
@@ -1,0 +1,42 @@
+import { type Accessor, createContext, createSignal, type JSX, useContext } from "solid-js";
+import type { LockableParam } from "@/lib/types";
+
+type LocksContextValue = {
+  locks: Accessor<Set<LockableParam>>;
+  isLocked: (param: LockableParam) => boolean;
+  toggleLock: (param: LockableParam) => void;
+};
+
+const LocksContext = createContext<LocksContextValue | null>(null);
+
+export function LocksProvider(props: { children: JSX.Element }) {
+  const [locks, setLocks] = createSignal<Set<LockableParam>>(new Set());
+
+  const isLocked = (param: LockableParam) => locks().has(param);
+
+  const toggleLock = (param: LockableParam) => {
+    setLocks((prev) => {
+      const next = new Set(prev);
+      if (next.has(param)) {
+        next.delete(param);
+      } else {
+        next.add(param);
+      }
+      return next;
+    });
+  };
+
+  return (
+    <LocksContext.Provider value={{ locks, isLocked, toggleLock }}>
+      {props.children}
+    </LocksContext.Provider>
+  );
+}
+
+export function useLocks(): LocksContextValue {
+  const context = useContext(LocksContext);
+  if (!context) {
+    throw new Error("useLocks must be used within a LocksProvider");
+  }
+  return context;
+}


### PR DESCRIPTION
## Summary

This PR implements the complete functionality for the **RandomButton**, **ResetButton**, and a new **Lock Mechanism** for the design system customizer pickers. These features allow users to:

- 🎲 **Randomize** design system parameters with a single click or keyboard shortcut
- 🔄 **Reset** all parameters to default values with confirmation
- 🔒 **Lock** specific parameters to prevent them from being randomized

## Changes Made

### New Files
- **`src/lib/use-locks.tsx`** - SolidJS context and hook for managing lock state
- **`src/components/lock-button.tsx`** - Lock toggle button component with tooltip

### Modified Files
- **`src/components/random-button.tsx`** - Implemented randomization logic that respects locked parameters
- **`src/components/reset-button.tsx`** - Added reset handler to restore DEFAULT_CONFIG values
- **`src/components/customizer.tsx`** - Wrapped with LocksProvider for shared lock state
- **`src/lib/types.ts`** - Added `LockableParam` type definition
- **6 Picker components** - Added LockButton to style, theme, baseColor, font, radius, and menuAccent pickers

## Implementation Details

### Lock Mechanism
- Uses SolidJS `createContext` and `createSignal` for state management
- Lock state is ephemeral (session-only, not persisted) - matches shadcn/ui behavior
- Lock buttons appear on hover (desktop) and are hidden on touch devices (`pointer-coarse:hidden`)
- Locked parameters show a filled lock icon; unlocked show an open lock icon

### RandomButton
- Randomizes all unlocked design parameters on click
- Responds to "R" keyboard shortcut (ignores when in input fields or with modifier keys)
- Combines theme colors with base colors for random theme selection
- Includes "default" in radius options

### ResetButton
- Opens confirmation dialog before resetting
- Resets all 6 parameters to `DEFAULT_CONFIG` values
- Uses TanStack Router navigation to update URL search params

## Testing

- ✅ TypeScript type checking passes
- ✅ Biome linting passes
- ✅ Pre-commit hooks pass (lefthook)
- ✅ Commitlint validation passes

### Manual Testing Checklist
- [ ] Click RandomButton - all unlocked pickers randomize
- [ ] Press "R" key - triggers randomization
- [ ] Lock a picker, randomize - locked value persists
- [ ] Click ResetButton, confirm - all values reset to defaults
- [ ] Hover over pickers - lock buttons appear

---

This PR was written using [Vibe Kanban](https://vibekanban.com)