### PR TITLE
docs(ui): standardize component documentation - remove Usage, ensure Examples (Vibe Kanban)

### DIFF
--- a/src/pages/ui/accordion.mdx
+++ b/src/pages/ui/accordion.mdx
@@ -24,28 +24,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from "~/components/ui/accordion";
-```
-
-```tsx showLineNumbers
-<Accordion>
-  <AccordionItem value="item-1">
-    <AccordionTrigger>Is it accessible?</AccordionTrigger>
-    <AccordionContent>
-      Yes. It adheres to the WAI-ARIA design pattern.
-    </AccordionContent>
-  </AccordionItem>
-</Accordion>
-```
-
 ## Examples
 
 Here are the source code of all the examples from the preview page:

--- a/src/pages/ui/alert-dialog.mdx
+++ b/src/pages/ui/alert-dialog.mdx
@@ -24,41 +24,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from "~/components/ui/alert-dialog";
-```
-
-```tsx showLineNumbers
-<AlertDialog>
-  <AlertDialogTrigger>Open</AlertDialogTrigger>
-  <AlertDialogContent>
-    <AlertDialogHeader>
-      <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
-      <AlertDialogDescription>
-        This action cannot be undone. This will permanently delete your account
-        and remove your data from our servers.
-      </AlertDialogDescription>
-    </AlertDialogHeader>
-    <AlertDialogFooter>
-      <AlertDialogCancel>Cancel</AlertDialogCancel>
-      <AlertDialogAction>Continue</AlertDialogAction>
-    </AlertDialogFooter>
-  </AlertDialogContent>
-</AlertDialog>
-```
-
 ## Examples
 
 Here are the source code of all the examples from the preview page:

--- a/src/pages/ui/alert.mdx
+++ b/src/pages/ui/alert.mdx
@@ -24,22 +24,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import { Alert, AlertDescription, AlertTitle } from "~/components/ui/alert";
-```
-
-```tsx showLineNumbers
-<Alert variant="default | destructive">
-  <Terminal />
-  <AlertTitle>Heads up!</AlertTitle>
-  <AlertDescription>
-    You can add components and dependencies to your app using the cli.
-  </AlertDescription>
-</Alert>
-```
-
 ## Examples
 
 Here are the source code of all the examples from the preview page:

--- a/src/pages/ui/aspect-ratio.mdx
+++ b/src/pages/ui/aspect-ratio.mdx
@@ -24,18 +24,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import { AspectRatio } from "~/components/ui/aspect-ratio";
-```
-
-```tsx showLineNumbers
-<AspectRatio ratio={16 / 9}>
-  <img src="..." alt="Image" class="rounded-md object-cover" />
-</AspectRatio>
-```
-
 ## Examples
 
 Here are the source code of all the examples from the preview page:

--- a/src/pages/ui/avatar.mdx
+++ b/src/pages/ui/avatar.mdx
@@ -24,19 +24,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
-```
-
-```tsx showLineNumbers
-<Avatar>
-  <AvatarImage src="https://github.com/shadcn.png" />
-  <AvatarFallback>CN</AvatarFallback>
-</Avatar>
-```
-
 ## Examples
 
 Here are the source code of all the examples from the preview page:

--- a/src/pages/ui/badge.mdx
+++ b/src/pages/ui/badge.mdx
@@ -24,32 +24,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import { Badge } from "~/components/ui/badge";
-```
-
-```tsx showLineNumbers
-<Badge variant="default | outline | secondary | destructive">Badge</Badge>
-```
-
-### Link
-
-You can use the `as` prop to render the badge as a different element. Here's an example of a link that looks like a badge.
-
-```tsx showLineNumbers
-import { Badge } from "~/components/ui/badge";
-
-export function LinkAsBadge() {
-  return (
-    <Badge as="a" href="/">
-      Badge
-    </Badge>
-  );
-}
-```
-
 ## Examples
 
 Here are the source code of all the examples from the preview page:

--- a/src/pages/ui/breadcrumb.mdx
+++ b/src/pages/ui/breadcrumb.mdx
@@ -24,37 +24,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator,
-} from "~/components/ui/breadcrumb";
-```
-
-```tsx showLineNumbers
-<Breadcrumb>
-  <BreadcrumbList>
-    <BreadcrumbItem>
-      <BreadcrumbLink href="/">Home</BreadcrumbLink>
-    </BreadcrumbItem>
-    <BreadcrumbSeparator />
-    <BreadcrumbItem>
-      <BreadcrumbLink href="/components">Components</BreadcrumbLink>
-    </BreadcrumbItem>
-    <BreadcrumbSeparator />
-    <BreadcrumbItem>
-      <BreadcrumbPage>Breadcrumb</BreadcrumbPage>
-    </BreadcrumbItem>
-  </BreadcrumbList>
-</Breadcrumb>
-```
-
 ## Examples
 
 Here are the source code of all the examples from the preview page:

--- a/src/pages/ui/button-group.mdx
+++ b/src/pages/ui/button-group.mdx
@@ -24,23 +24,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import {
-  ButtonGroup,
-  ButtonGroupSeparator,
-  ButtonGroupText,
-} from "~/components/ui/button-group";
-```
-
-```tsx showLineNumbers
-<ButtonGroup>
-  <Button>Button 1</Button>
-  <Button>Button 2</Button>
-</ButtonGroup>
-```
-
 ## Accessibility
 
 - The `ButtonGroup` component has the `role` attribute set to `group`.

--- a/src/pages/ui/button.mdx
+++ b/src/pages/ui/button.mdx
@@ -24,16 +24,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import { Button } from "~/components/ui/button";
-```
-
-```tsx showLineNumbers
-<Button variant="outline">Button</Button>
-```
-
 ## Examples
 
 Here are the source code of all the examples from the preview page:

--- a/src/pages/ui/calendar.mdx
+++ b/src/pages/ui/calendar.mdx
@@ -31,24 +31,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import { Calendar } from "~/components/ui/calendar";
-```
-
-```tsx showLineNumbers
-import { createSignal } from "solid-js";
-
-const [date, setDate] = createSignal<Date | null>(null);
-
-<Calendar
-  mode="single"
-  value={date()}
-  onValueChange={setDate}
-/>
-```
-
 ## About
 
 The Calendar component is built on top of [Corvu Calendar](https://corvu.dev/docs/primitives/calendar/). It provides a fully accessible date selection component with keyboard navigation and support for single, multiple, and range selection modes.

--- a/src/pages/ui/card.mdx
+++ b/src/pages/ui/card.mdx
@@ -24,36 +24,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import {
-  Card,
-  CardAction,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "~/components/ui/card";
-```
-
-```tsx showLineNumbers
-<Card>
-  <CardHeader>
-    <CardTitle>Card Title</CardTitle>
-    <CardDescription>Card Description</CardDescription>
-    <CardAction>Card Action</CardAction>
-  </CardHeader>
-  <CardContent>
-    <p>Card Content</p>
-  </CardContent>
-  <CardFooter>
-    <p>Card Footer</p>
-  </CardFooter>
-</Card>
-```
-
 ## Examples
 
 Here are the source code of all the examples from the preview page:

--- a/src/pages/ui/carousel.mdx
+++ b/src/pages/ui/carousel.mdx
@@ -34,30 +34,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import {
-  Carousel,
-  CarouselContent,
-  CarouselItem,
-  CarouselNext,
-  CarouselPrevious,
-} from "~/components/ui/carousel";
-```
-
-```tsx showLineNumbers
-<Carousel>
-  <CarouselContent>
-    <CarouselItem>...</CarouselItem>
-    <CarouselItem>...</CarouselItem>
-    <CarouselItem>...</CarouselItem>
-  </CarouselContent>
-  <CarouselPrevious />
-  <CarouselNext />
-</Carousel>
-```
-
 ## Options
 
 You can pass options to the carousel using the `opts` prop. See the [Embla Carousel docs](https://www.embla-carousel.com/api/options/) for more information.

--- a/src/pages/ui/chart.mdx
+++ b/src/pages/ui/chart.mdx
@@ -29,48 +29,6 @@ You'll also need to install the ECharts dependency:
 bun add echarts
 ```
 
-## Usage
-
-```tsx
-import {
-  ChartContainer,
-  chartColors,
-  chartGridDefaults,
-  chartTooltipDefaults,
-  chartXAxisDefaults,
-  chartYAxisDefaults,
-} from "@/registry/ui/chart"
-
-const data = [
-  { month: "Jan", value: 186 },
-  { month: "Feb", value: 305 },
-  { month: "Mar", value: 237 },
-]
-
-export function MyChart() {
-  const option = {
-    color: chartColors,
-    tooltip: chartTooltipDefaults,
-    grid: chartGridDefaults,
-    xAxis: {
-      ...chartXAxisDefaults,
-      type: "category",
-      data: data.map(d => d.month),
-    },
-    yAxis: {
-      ...chartYAxisDefaults,
-      type: "value",
-    },
-    series: [{
-      type: "bar",
-      data: data.map(d => d.value),
-    }],
-  }
-
-  return <ChartContainer option={option} class="h-[300px]" />
-}
-```
-
 ## Chart Configuration
 
 The `ChartConfig` type allows you to define labels, colors, and icons for each data series:
@@ -348,4 +306,102 @@ type ChartConfig = {
     theme?: { light: string; dark: string }
   }
 }
+```
+
+## Examples
+
+Here are the source code of all the examples from the preview page:
+
+### Area Chart
+
+```tsx
+import type { ECBasicOption } from "echarts/types/dist/shared";
+import {
+  type ChartConfig,
+  ChartContainer,
+  chartColors,
+  chartGridDefaults,
+  chartTooltipDefaults,
+  chartXAxisDefaults,
+  chartYAxisDefaults,
+} from "~/components/ui/chart";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "~/components/ui/card";
+```
+
+```tsx file=../../registry/examples/chart-example.tsx#L48-L101
+
+```
+
+### Bar Chart
+
+```tsx
+import type { ECBasicOption } from "echarts/types/dist/shared";
+import {
+  type ChartConfig,
+  ChartContainer,
+  chartColors,
+  chartGridDefaults,
+  chartTooltipDefaults,
+  chartXAxisDefaults,
+  chartYAxisDefaults,
+} from "~/components/ui/chart";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "~/components/ui/card";
+```
+
+```tsx file=../../registry/examples/chart-example.tsx#L103-L164
+
+```
+
+### Line Chart
+
+```tsx
+import type { ECBasicOption } from "echarts/types/dist/shared";
+import {
+  type ChartConfig,
+  ChartContainer,
+  chartColors,
+  chartGridDefaults,
+  chartLegendDefaults,
+  chartTooltipDefaults,
+  chartXAxisDefaults,
+  chartYAxisDefaults,
+} from "~/components/ui/chart";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "~/components/ui/card";
+```
+
+```tsx file=../../registry/examples/chart-example.tsx#L166-L231
+
+```
+
+### Pie Chart
+
+```tsx
+import type { ECBasicOption } from "echarts/types/dist/shared";
+import {
+  type ChartConfig,
+  ChartContainer,
+  chartColors,
+  chartLegendDefaults,
+} from "~/components/ui/chart";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "~/components/ui/card";
+```
+
+```tsx file=../../registry/examples/chart-example.tsx#L233-L305
+
+```
+
+### Radar Chart
+
+```tsx
+import type { ECBasicOption } from "echarts/types/dist/shared";
+import {
+  ChartContainer,
+  chartColors,
+  chartLegendDefaults,
+} from "~/components/ui/chart";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "~/components/ui/card";
+```
+
+```tsx file=../../registry/examples/chart-example.tsx#L307-L391
+
 ```

--- a/src/pages/ui/checkbox.mdx
+++ b/src/pages/ui/checkbox.mdx
@@ -30,18 +30,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import { Checkbox, CheckboxLabel } from "~/components/ui/checkbox";
-```
-
-```tsx showLineNumbers
-<Checkbox>
-  <CheckboxLabel>Accept terms and conditions</CheckboxLabel>
-</Checkbox>
-```
-
 ## Examples
 
 Here are the source code of all the examples from the preview page:

--- a/src/pages/ui/collapsible.mdx
+++ b/src/pages/ui/collapsible.mdx
@@ -24,26 +24,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "~/components/ui/collapsible";
-```
-
-```tsx showLineNumbers
-<Collapsible>
-  <CollapsibleTrigger>Can I use this in my project?</CollapsibleTrigger>
-  <CollapsibleContent>
-    Yes. Free to use for personal and commercial projects. No attribution
-    required.
-  </CollapsibleContent>
-</Collapsible>
-```
-
 ## Examples
 
 Here are the source code of all the examples from the preview page:

--- a/src/pages/ui/combobox.mdx
+++ b/src/pages/ui/combobox.mdx
@@ -25,43 +25,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import {
-  Combobox,
-  ComboboxContent,
-  ComboboxEmpty,
-  ComboboxInput,
-  ComboboxItem,
-} from "~/components/ui/combobox";
-```
-
-```tsx showLineNumbers
-const frameworks = [
-  { label: "Next.js", value: "nextjs" },
-  { label: "SvelteKit", value: "sveltekit" },
-  { label: "Nuxt.js", value: "nuxtjs" },
-  { label: "Remix", value: "remix" },
-  { label: "Astro", value: "astro" },
-];
-
-<Combobox
-  options={frameworks}
-  optionValue="value"
-  optionTextValue="label"
-  placeholder="Select a framework..."
-  itemComponent={(props) => (
-    <ComboboxItem item={props.item}>{props.item.rawValue.label}</ComboboxItem>
-  )}
->
-  <ComboboxInput placeholder="Select a framework..." />
-  <ComboboxContent>
-    <ComboboxEmpty>No frameworks found.</ComboboxEmpty>
-  </ComboboxContent>
-</Combobox>
-```
-
 ## Props
 
 The Combobox component uses Kobalte's Combobox primitive under the hood. Here are the main props:

--- a/src/pages/ui/command.mdx
+++ b/src/pages/ui/command.mdx
@@ -25,51 +25,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import {
-  Command,
-  CommandDialog,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-  CommandSeparator,
-  CommandShortcut,
-} from "~/components/ui/command";
-```
-
-```tsx showLineNumbers
-<CommandDialog open={open()} onOpenChange={setOpen}>
-  <Command>
-    <CommandInput placeholder="Type a command or search..." />
-    <CommandList>
-      <CommandEmpty>No results found.</CommandEmpty>
-      <CommandGroup heading="Suggestions">
-        <CommandItem value="calendar">Calendar</CommandItem>
-        <CommandItem value="search-emoji">Search Emoji</CommandItem>
-        <CommandItem value="calculator">Calculator</CommandItem>
-      </CommandGroup>
-      <CommandSeparator />
-      <CommandGroup heading="Settings">
-        <CommandItem value="profile">
-          <User />
-          <span>Profile</span>
-          <CommandShortcut>⌘P</CommandShortcut>
-        </CommandItem>
-        <CommandItem value="settings">
-          <Settings />
-          <span>Settings</span>
-          <CommandShortcut>⌘S</CommandShortcut>
-        </CommandItem>
-      </CommandGroup>
-    </CommandList>
-  </Command>
-</CommandDialog>
-```
-
 ## Props
 
 ### Command

--- a/src/pages/ui/context-menu.mdx
+++ b/src/pages/ui/context-menu.mdx
@@ -24,29 +24,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import {
-  ContextMenu,
-  ContextMenuContent,
-  ContextMenuItem,
-  ContextMenuTrigger,
-} from "~/components/ui/context-menu";
-```
-
-```tsx showLineNumbers
-<ContextMenu>
-  <ContextMenuTrigger>Right click</ContextMenuTrigger>
-  <ContextMenuContent>
-    <ContextMenuItem>Profile</ContextMenuItem>
-    <ContextMenuItem>Billing</ContextMenuItem>
-    <ContextMenuItem>Team</ContextMenuItem>
-    <ContextMenuItem>Subscription</ContextMenuItem>
-  </ContextMenuContent>
-</ContextMenu>
-```
-
 ## Examples
 
 Here are the source code of all the examples from the preview page:

--- a/src/pages/ui/dialog.mdx
+++ b/src/pages/ui/dialog.mdx
@@ -24,34 +24,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "~/components/ui/dialog";
-```
-
-```tsx showLineNumbers
-<Dialog>
-  <DialogTrigger>Open</DialogTrigger>
-  <DialogContent>
-    <DialogHeader>
-      <DialogTitle>Are you absolutely sure?</DialogTitle>
-      <DialogDescription>
-        This action cannot be undone. This will permanently delete your account
-        and remove your data from our servers.
-      </DialogDescription>
-    </DialogHeader>
-  </DialogContent>
-</Dialog>
-```
-
 ## Examples
 
 Here are the source code of all the examples from the preview page:

--- a/src/pages/ui/drawer.mdx
+++ b/src/pages/ui/drawer.mdx
@@ -34,39 +34,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import {
-  Drawer,
-  DrawerClose,
-  DrawerContent,
-  DrawerDescription,
-  DrawerFooter,
-  DrawerHeader,
-  DrawerTitle,
-  DrawerTrigger,
-} from "~/components/ui/drawer";
-```
-
-```tsx showLineNumbers
-<Drawer>
-  <DrawerTrigger>Open</DrawerTrigger>
-  <DrawerContent>
-    <DrawerHeader>
-      <DrawerTitle>Are you absolutely sure?</DrawerTitle>
-      <DrawerDescription>This action cannot be undone.</DrawerDescription>
-    </DrawerHeader>
-    <DrawerFooter>
-      <Button>Submit</Button>
-      <DrawerClose>
-        <Button variant="outline">Cancel</Button>
-      </DrawerClose>
-    </DrawerFooter>
-  </DrawerContent>
-</Drawer>
-```
-
 ## Examples
 
 Here are the source code of all the examples from the preview page:

--- a/src/pages/ui/dropdown-menu.mdx
+++ b/src/pages/ui/dropdown-menu.mdx
@@ -24,33 +24,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "~/components/ui/dropdown-menu";
-```
-
-```tsx showLineNumbers
-<DropdownMenu>
-  <DropdownMenuTrigger>Open</DropdownMenuTrigger>
-  <DropdownMenuContent>
-    <DropdownMenuLabel>My Account</DropdownMenuLabel>
-    <DropdownMenuSeparator />
-    <DropdownMenuItem>Profile</DropdownMenuItem>
-    <DropdownMenuItem>Billing</DropdownMenuItem>
-    <DropdownMenuItem>Team</DropdownMenuItem>
-    <DropdownMenuItem>Subscription</DropdownMenuItem>
-  </DropdownMenuContent>
-</DropdownMenu>
-```
-
 ## Examples
 
 Here are the source code of all the examples from the preview page:

--- a/src/pages/ui/empty.mdx
+++ b/src/pages/ui/empty.mdx
@@ -24,34 +24,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import {
-  Empty,
-  EmptyContent,
-  EmptyDescription,
-  EmptyHeader,
-  EmptyMedia,
-  EmptyTitle,
-} from "~/components/ui/empty";
-```
-
-```tsx showLineNumbers
-<Empty>
-  <EmptyHeader>
-    <EmptyMedia variant="icon">
-      <Icon />
-    </EmptyMedia>
-    <EmptyTitle>No data</EmptyTitle>
-    <EmptyDescription>No data found</EmptyDescription>
-  </EmptyHeader>
-  <EmptyContent>
-    <Button>Add data</Button>
-  </EmptyContent>
-</Empty>
-```
-
 ## Examples
 
 Here are the source code of all the examples from the preview page:

--- a/src/pages/ui/field.mdx
+++ b/src/pages/ui/field.mdx
@@ -24,46 +24,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import {
-  Field,
-  FieldContent,
-  FieldDescription,
-  FieldError,
-  FieldGroup,
-  FieldLabel,
-  FieldLegend,
-  FieldSeparator,
-  FieldSet,
-  FieldTitle,
-} from "~/components/ui/field";
-```
-
-```tsx showLineNumbers
-<FieldSet>
-  <FieldLegend>Profile</FieldLegend>
-  <FieldDescription>This appears on invoices and emails.</FieldDescription>
-  <FieldGroup>
-    <Field>
-      <FieldLabel for="name">Full name</FieldLabel>
-      <Input id="name" autocomplete="off" placeholder="Evil Rabbit" />
-      <FieldDescription>This appears on invoices and emails.</FieldDescription>
-    </Field>
-    <Field>
-      <FieldLabel for="username">Username</FieldLabel>
-      <Input id="username" autocomplete="off" aria-invalid />
-      <FieldError>Choose another username.</FieldError>
-    </Field>
-    <Field orientation="horizontal">
-      <Switch id="newsletter" />
-      <FieldLabel for="newsletter">Subscribe to the newsletter</FieldLabel>
-    </Field>
-  </FieldGroup>
-</FieldSet>
-```
-
 ## Anatomy
 
 The `Field` family is designed for composing accessible forms. A typical field is structured as follows:

--- a/src/pages/ui/hover-card.mdx
+++ b/src/pages/ui/hover-card.mdx
@@ -24,25 +24,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import {
-  HoverCard,
-  HoverCardContent,
-  HoverCardTrigger,
-} from "~/components/ui/hover-card";
-```
-
-```tsx showLineNumbers
-<HoverCard>
-  <HoverCardTrigger>Hover</HoverCardTrigger>
-  <HoverCardContent>
-    The SolidJS Framework - Simple and performant reactivity for building user interfaces.
-  </HoverCardContent>
-</HoverCard>
-```
-
 ## Examples
 
 Here are the source code of all the examples from the preview page:

--- a/src/pages/ui/input-group.mdx
+++ b/src/pages/ui/input-group.mdx
@@ -24,31 +24,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import {
-  InputGroup,
-  InputGroupAddon,
-  InputGroupButton,
-  InputGroupInput,
-  InputGroupText,
-  InputGroupTextarea,
-} from "~/components/ui/input-group";
-```
-
-```tsx showLineNumbers
-<InputGroup>
-  <InputGroupInput placeholder="Search..." />
-  <InputGroupAddon>
-    <SearchIcon />
-  </InputGroupAddon>
-  <InputGroupAddon align="inline-end">
-    <InputGroupButton>Search</InputGroupButton>
-  </InputGroupAddon>
-</InputGroup>
-```
-
 ## Examples
 
 Here are the source code of all the examples from the preview page:

--- a/src/pages/ui/input-otp.mdx
+++ b/src/pages/ui/input-otp.mdx
@@ -30,33 +30,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import {
-  InputOTP,
-  InputOTPGroup,
-  InputOTPSeparator,
-  InputOTPSlot,
-} from "~/components/ui/input-otp";
-```
-
-```tsx showLineNumbers
-<InputOTP maxLength={6}>
-  <InputOTPGroup>
-    <InputOTPSlot index={0} />
-    <InputOTPSlot index={1} />
-    <InputOTPSlot index={2} />
-  </InputOTPGroup>
-  <InputOTPSeparator />
-  <InputOTPGroup>
-    <InputOTPSlot index={3} />
-    <InputOTPSlot index={4} />
-    <InputOTPSlot index={5} />
-  </InputOTPGroup>
-</InputOTP>
-```
-
 ## Examples
 
 Here are the source code of all the examples from the preview page:

--- a/src/pages/ui/input.mdx
+++ b/src/pages/ui/input.mdx
@@ -24,16 +24,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import { Input } from "~/components/ui/input";
-```
-
-```tsx showLineNumbers
-<Input />
-```
-
 ## Examples
 
 Here are the source code of all the examples from the preview page:

--- a/src/pages/ui/item.mdx
+++ b/src/pages/ui/item.mdx
@@ -24,39 +24,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import {
-  Item,
-  ItemActions,
-  ItemContent,
-  ItemDescription,
-  ItemFooter,
-  ItemHeader,
-  ItemMedia,
-  ItemSeparator,
-  ItemTitle,
-} from "~/components/ui/item";
-```
-
-```tsx showLineNumbers
-<Item>
-  <ItemHeader>Item Header</ItemHeader>
-  <ItemMedia variant="icon">
-    <Icon />
-  </ItemMedia>
-  <ItemContent>
-    <ItemTitle>Item Title</ItemTitle>
-    <ItemDescription>Item description</ItemDescription>
-  </ItemContent>
-  <ItemActions>
-    <Button>Action</Button>
-  </ItemActions>
-  <ItemFooter>Item Footer</ItemFooter>
-</Item>
-```
-
 ## API Reference
 
 ### Item

--- a/src/pages/ui/kbd.mdx
+++ b/src/pages/ui/kbd.mdx
@@ -24,16 +24,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import { Kbd, KbdGroup } from "~/components/ui/kbd";
-```
-
-```tsx showLineNumbers
-<Kbd>Ctrl</Kbd>
-```
-
 ## Examples
 
 Here are the source code of all the examples from the preview page:

--- a/src/pages/ui/label.mdx
+++ b/src/pages/ui/label.mdx
@@ -24,16 +24,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import { Label } from "~/components/ui/label";
-```
-
-```tsx showLineNumbers
-<Label for="email">Your email address</Label>
-```
-
 ## Examples
 
 Here are the source code of all the examples from the preview page:

--- a/src/pages/ui/menubar.mdx
+++ b/src/pages/ui/menubar.mdx
@@ -30,38 +30,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import {
-  Menubar,
-  MenubarContent,
-  MenubarItem,
-  MenubarMenu,
-  MenubarSeparator,
-  MenubarShortcut,
-  MenubarTrigger,
-} from "~/components/ui/menubar";
-```
-
-```tsx showLineNumbers
-<Menubar>
-  <MenubarMenu>
-    <MenubarTrigger>File</MenubarTrigger>
-    <MenubarContent>
-      <MenubarItem>
-        New Tab <MenubarShortcut>⌘T</MenubarShortcut>
-      </MenubarItem>
-      <MenubarItem>New Window</MenubarItem>
-      <MenubarSeparator />
-      <MenubarItem>Share</MenubarItem>
-      <MenubarSeparator />
-      <MenubarItem>Print</MenubarItem>
-    </MenubarContent>
-  </MenubarMenu>
-</Menubar>
-```
-
 ## Examples
 
 Here are the source code of all the examples from the preview page:

--- a/src/pages/ui/native-select.mdx
+++ b/src/pages/ui/native-select.mdx
@@ -24,29 +24,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import {
-  NativeSelect,
-  NativeSelectOptGroup,
-  NativeSelectOption,
-} from "~/components/ui/native-select";
-```
-
-```tsx showLineNumbers
-<NativeSelect>
-  <NativeSelectOption value="">Select a fruit</NativeSelectOption>
-  <NativeSelectOption value="apple">Apple</NativeSelectOption>
-  <NativeSelectOption value="banana">Banana</NativeSelectOption>
-  <NativeSelectOption value="blueberry">Blueberry</NativeSelectOption>
-  <NativeSelectOption value="grapes" disabled>
-    Grapes
-  </NativeSelectOption>
-  <NativeSelectOption value="pineapple">Pineapple</NativeSelectOption>
-</NativeSelect>
-```
-
 ## Examples
 
 Here are the source code of all the examples from the preview page:

--- a/src/pages/ui/navigation-menu.mdx
+++ b/src/pages/ui/navigation-menu.mdx
@@ -24,31 +24,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import {
-  NavigationMenu,
-  NavigationMenuContent,
-  NavigationMenuIndicator,
-  NavigationMenuItem,
-  NavigationMenuLink,
-  NavigationMenuTrigger,
-  navigationMenuTriggerStyle,
-} from "~/components/ui/navigation-menu";
-```
-
-```tsx showLineNumbers
-<NavigationMenu>
-  <NavigationMenuItem>
-    <NavigationMenuTrigger>Item One</NavigationMenuTrigger>
-    <NavigationMenuContent>
-      <NavigationMenuLink>Link</NavigationMenuLink>
-    </NavigationMenuContent>
-  </NavigationMenuItem>
-</NavigationMenu>
-```
-
 ## Link
 
 You can use the `as` prop to make another component render as a navigation menu link.

--- a/src/pages/ui/pagination.mdx
+++ b/src/pages/ui/pagination.mdx
@@ -24,47 +24,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import {
-  Pagination,
-  PaginationContent,
-  PaginationEllipsis,
-  PaginationItem,
-  PaginationLink,
-  PaginationNext,
-  PaginationPrevious,
-} from "~/components/ui/pagination";
-```
-
-```tsx showLineNumbers
-<Pagination>
-  <PaginationContent>
-    <PaginationItem>
-      <PaginationPrevious href="#" />
-    </PaginationItem>
-    <PaginationItem>
-      <PaginationLink href="#">1</PaginationLink>
-    </PaginationItem>
-    <PaginationItem>
-      <PaginationLink href="#" isActive>
-        2
-      </PaginationLink>
-    </PaginationItem>
-    <PaginationItem>
-      <PaginationLink href="#">3</PaginationLink>
-    </PaginationItem>
-    <PaginationItem>
-      <PaginationEllipsis />
-    </PaginationItem>
-    <PaginationItem>
-      <PaginationNext href="#" />
-    </PaginationItem>
-  </PaginationContent>
-</Pagination>
-```
-
 ## SolidJS Router
 
 By default, the `<PaginationLink />` component will render an `<a>` element. You can use the `as` prop to render a different component, such as a SolidJS Router `<A>` component.

--- a/src/pages/ui/popover.mdx
+++ b/src/pages/ui/popover.mdx
@@ -24,23 +24,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "~/components/ui/popover";
-```
-
-```tsx showLineNumbers
-<Popover>
-  <PopoverTrigger>Open</PopoverTrigger>
-  <PopoverContent>Place content for the popover here.</PopoverContent>
-</Popover>
-```
-
 ## Examples
 
 Here are the source code of all the examples from the preview page:

--- a/src/pages/ui/progress.mdx
+++ b/src/pages/ui/progress.mdx
@@ -24,16 +24,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import { Progress } from "~/components/ui/progress";
-```
-
-```tsx showLineNumbers
-<Progress value={33} />
-```
-
 ## With Label
 
 ```tsx

--- a/src/pages/ui/radio-group.mdx
+++ b/src/pages/ui/radio-group.mdx
@@ -30,25 +30,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import { RadioGroup, RadioGroupItem } from "~/components/ui/radio-group";
-```
-
-```tsx showLineNumbers
-<RadioGroup defaultValue="option1">
-  <div class="flex items-center gap-3">
-    <RadioGroupItem value="option1" />
-    <label for="option1">Option 1</label>
-  </div>
-  <div class="flex items-center gap-3">
-    <RadioGroupItem value="option2" />
-    <label for="option2">Option 2</label>
-  </div>
-</RadioGroup>
-```
-
 ## Examples
 
 Here are the source code of all the examples from the preview page:

--- a/src/pages/ui/resizable.mdx
+++ b/src/pages/ui/resizable.mdx
@@ -30,24 +30,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import {
-  ResizablePanelGroup,
-  ResizablePanel,
-  ResizableHandle,
-} from "~/components/ui/resizable";
-```
-
-```tsx showLineNumbers
-<ResizablePanelGroup orientation="horizontal">
-  <ResizablePanel>One</ResizablePanel>
-  <ResizableHandle />
-  <ResizablePanel>Two</ResizablePanel>
-</ResizablePanelGroup>
-```
-
 ## Examples
 
 Here are the source code of all the examples from the preview page:

--- a/src/pages/ui/select.mdx
+++ b/src/pages/ui/select.mdx
@@ -25,43 +25,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "~/components/ui/select";
-```
-
-```tsx showLineNumbers
-const items = [
-  { label: "Light", value: "light" },
-  { label: "Dark", value: "dark" },
-  { label: "System", value: "system" },
-];
-
-<Select
-  options={items}
-  optionValue="value"
-  optionTextValue="label"
-  placeholder="Theme"
-  itemComponent={(props) => (
-    <SelectItem item={props.item}>{props.item.rawValue.label}</SelectItem>
-  )}
->
-  <SelectTrigger class="w-[180px]">
-    <SelectValue<(typeof items)[number]>>
-      {(state) => state.selectedOption().label}
-    </SelectValue>
-  </SelectTrigger>
-  <SelectContent />
-</Select>
-```
-
 ## Props
 
 The Select component uses Kobalte's Select primitive under the hood. Here are the main props:

--- a/src/pages/ui/separator.mdx
+++ b/src/pages/ui/separator.mdx
@@ -24,16 +24,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import { Separator } from "~/components/ui/separator";
-```
-
-```tsx showLineNumbers
-<Separator />
-```
-
 ## Examples
 
 Here are the source code of all the examples from the preview page:

--- a/src/pages/ui/sheet.mdx
+++ b/src/pages/ui/sheet.mdx
@@ -30,34 +30,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle,
-  SheetTrigger,
-} from "~/components/ui/sheet";
-```
-
-```tsx showLineNumbers
-<Sheet>
-  <SheetTrigger>Open</SheetTrigger>
-  <SheetContent>
-    <SheetHeader>
-      <SheetTitle>Are you absolutely sure?</SheetTitle>
-      <SheetDescription>
-        This action cannot be undone. This will permanently delete your account
-        and remove your data from our servers.
-      </SheetDescription>
-    </SheetHeader>
-  </SheetContent>
-</Sheet>
-```
-
 ## Examples
 
 Here are the source code of all the examples from the preview page:

--- a/src/pages/ui/sidebar-floating.mdx
+++ b/src/pages/ui/sidebar-floating.mdx
@@ -12,50 +12,6 @@ A sidebar variant that appears to float with rounded corners and padding, creati
 
 See the [Sidebar](/ui/sidebar) component for installation instructions.
 
-## Usage
-
-```tsx
-import {
-  Sidebar,
-  SidebarContent,
-  SidebarGroup,
-  SidebarHeader,
-  SidebarInset,
-  SidebarMenu,
-  SidebarMenuButton,
-  SidebarMenuItem,
-  SidebarMenuSub,
-  SidebarMenuSubButton,
-  SidebarMenuSubItem,
-  SidebarProvider,
-  SidebarTrigger,
-} from "~/components/ui/sidebar";
-```
-
-```tsx showLineNumbers
-<SidebarProvider
-  style={{
-    "--sidebar-width": "19rem",
-  }}
->
-  <Sidebar variant="floating">
-    <SidebarHeader>
-      {/* Logo and branding */}
-    </SidebarHeader>
-    <SidebarContent>
-      <SidebarGroup>
-        <SidebarMenu class="gap-2">
-          {/* Navigation items */}
-        </SidebarMenu>
-      </SidebarGroup>
-    </SidebarContent>
-  </Sidebar>
-  <SidebarInset>
-    {/* Main content */}
-  </SidebarInset>
-</SidebarProvider>
-```
-
 ## Features
 
 - Floating appearance with rounded corners
@@ -74,6 +30,46 @@ import {
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `--sidebar-width` | `16rem` | Width of the sidebar |
+
+## Examples
+
+Here is the source code of the example from the preview page:
+
+### Floating Variant
+
+```tsx
+import { GalleryVerticalEnd } from "lucide-solid";
+import type { JSX } from "solid-js";
+import { For, Show } from "solid-js";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "~/components/ui/breadcrumb";
+import { Separator } from "~/components/ui/separator";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarGroup,
+  SidebarHeader,
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
+  SidebarProvider,
+  SidebarTrigger,
+} from "~/components/ui/sidebar";
+```
+
+```tsx file=../../registry/examples/sidebar-floating-example.tsx#L89-L174
+
+```
 
 ## See Also
 

--- a/src/pages/ui/sidebar-icon.mdx
+++ b/src/pages/ui/sidebar-icon.mdx
@@ -12,42 +12,6 @@ A sidebar variant that collapses to show only icons, enabling space-efficient na
 
 See the [Sidebar](/ui/sidebar) component for installation instructions.
 
-## Usage
-
-```tsx
-import {
-  Sidebar,
-  SidebarContent,
-  SidebarFooter,
-  SidebarHeader,
-  SidebarInset,
-  SidebarProvider,
-  SidebarRail,
-  SidebarTrigger,
-  useSidebar,
-} from "~/components/ui/sidebar";
-```
-
-```tsx showLineNumbers
-<SidebarProvider>
-  <Sidebar collapsible="icon">
-    <SidebarHeader>
-      {/* Header with team switcher */}
-    </SidebarHeader>
-    <SidebarContent>
-      {/* Navigation with icons */}
-    </SidebarContent>
-    <SidebarFooter>
-      {/* User profile */}
-    </SidebarFooter>
-    <SidebarRail />
-  </Sidebar>
-  <SidebarInset>
-    {/* Main content */}
-  </SidebarInset>
-</SidebarProvider>
-```
-
 ## Features
 
 - Collapses to icon-only mode for compact navigation
@@ -60,6 +24,86 @@ import {
 | Prop | Type | Value | Description |
 |------|------|-------|-------------|
 | `collapsible` | `string` | `"icon"` | Enables icon collapse mode |
+
+## Examples
+
+Here is the source code of the example from the preview page:
+
+### Icon Collapsible
+
+```tsx
+import {
+  AudioWaveform,
+  BadgeCheck,
+  Bell,
+  BookOpen,
+  Bot,
+  ChevronRight,
+  ChevronsUpDown,
+  Command,
+  CreditCard,
+  Folder,
+  Forward,
+  Frame,
+  GalleryVerticalEnd,
+  LogOut,
+  Map as MapIcon,
+  MoreHorizontal,
+  PieChart,
+  Plus,
+  Settings2,
+  Sparkles,
+  SquareTerminal,
+  Trash2,
+} from "lucide-solid";
+import type { Component, ComponentProps } from "solid-js";
+import { createSignal, For, Show } from "solid-js";
+import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "~/components/ui/breadcrumb";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "~/components/ui/collapsible";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "~/components/ui/dropdown-menu";
+import { Kbd } from "~/components/ui/kbd";
+import { Separator } from "~/components/ui/separator";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuAction,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
+  SidebarProvider,
+  SidebarRail,
+  SidebarTrigger,
+  useSidebar,
+} from "~/components/ui/sidebar";
+```
+
+```tsx file=../../registry/examples/sidebar-icon-example.tsx#L370-L415
+
+```
 
 ## See Also
 

--- a/src/pages/ui/sidebar-inset.mdx
+++ b/src/pages/ui/sidebar-inset.mdx
@@ -12,9 +12,36 @@ A sidebar variant that appears inset within the main content area, creating a di
 
 See the [Sidebar](/ui/sidebar) component for installation instructions.
 
-## Usage
+## Features
+
+- Inset appearance within the content area
+- Perfect for table of contents or secondary navigation
+- Works well on the right side of the page
+- Maintains visual hierarchy with the main content
+
+## Props
+
+| Prop | Type | Value | Description |
+|------|------|-------|-------------|
+| `variant` | `string` | `"inset"` | Enables inset visual style |
+| `side` | `string` | `"right"` | Positions sidebar on the right |
+
+## Examples
+
+Here is the source code of the example from the preview page:
+
+### Inset Variant
 
 ```tsx
+import { For, Show } from "solid-js";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "~/components/ui/breadcrumb";
 import {
   Sidebar,
   SidebarContent,
@@ -34,42 +61,9 @@ import {
 } from "~/components/ui/sidebar";
 ```
 
-```tsx showLineNumbers
-<SidebarProvider>
-  <SidebarInset>
-    <header>
-      {/* Header with breadcrumb and trigger */}
-      <SidebarTrigger class="rotate-180" />
-    </header>
-    {/* Main content */}
-  </SidebarInset>
-  <Sidebar variant="inset" side="right">
-    <SidebarContent>
-      <SidebarGroup>
-        <SidebarGroupLabel>Table of Contents</SidebarGroupLabel>
-        <SidebarGroupContent>
-          {/* Navigation items */}
-        </SidebarGroupContent>
-      </SidebarGroup>
-    </SidebarContent>
-    <SidebarRail />
-  </Sidebar>
-</SidebarProvider>
+```tsx file=../../registry/examples/sidebar-inset-example.tsx#L88-L155
+
 ```
-
-## Features
-
-- Inset appearance within the content area
-- Perfect for table of contents or secondary navigation
-- Works well on the right side of the page
-- Maintains visual hierarchy with the main content
-
-## Props
-
-| Prop | Type | Value | Description |
-|------|------|-------|-------------|
-| `variant` | `string` | `"inset"` | Enables inset visual style |
-| `side` | `string` | `"right"` | Positions sidebar on the right |
 
 ## See Also
 

--- a/src/pages/ui/sidebar.mdx
+++ b/src/pages/ui/sidebar.mdx
@@ -46,52 +46,6 @@ The sidebar component supports multiple variants and collapsible modes:
 - `icon` - Collapses to show only icons
 - `none` - Non-collapsible fixed sidebar
 
-## Usage
-
-```tsx
-import {
-  Sidebar,
-  SidebarContent,
-  SidebarFooter,
-  SidebarGroup,
-  SidebarGroupContent,
-  SidebarGroupLabel,
-  SidebarHeader,
-  SidebarInset,
-  SidebarMenu,
-  SidebarMenuButton,
-  SidebarMenuItem,
-  SidebarProvider,
-  SidebarRail,
-  SidebarTrigger,
-} from "~/components/ui/sidebar";
-```
-
-```tsx showLineNumbers
-<SidebarProvider>
-  <Sidebar>
-    <SidebarHeader>
-      {/* Header content */}
-    </SidebarHeader>
-    <SidebarContent>
-      <SidebarGroup>
-        <SidebarGroupLabel>Menu</SidebarGroupLabel>
-        <SidebarGroupContent>
-          <SidebarMenu>
-            <SidebarMenuItem>
-              <SidebarMenuButton>Item</SidebarMenuButton>
-            </SidebarMenuItem>
-          </SidebarMenu>
-        </SidebarGroupContent>
-      </SidebarGroup>
-    </SidebarContent>
-  </Sidebar>
-  <SidebarInset>
-    {/* Main content */}
-  </SidebarInset>
-</SidebarProvider>
-```
-
 ## Props
 
 ### Sidebar
@@ -113,6 +67,53 @@ import {
 ## Keyboard Shortcuts
 
 - `Cmd+B` (Mac) / `Ctrl+B` (Windows) - Toggle sidebar
+
+## Examples
+
+Here is the source code of the example from the preview page:
+
+### Basic
+
+```tsx
+import { Check, ChevronsUpDown, Search } from "lucide-solid";
+import { createSignal, For, Show } from "solid-js";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "~/components/ui/breadcrumb";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "~/components/ui/dropdown-menu";
+import { Label } from "~/components/ui/label";
+import { Separator } from "~/components/ui/separator";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarInput,
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarProvider,
+  SidebarRail,
+  SidebarTrigger,
+} from "~/components/ui/sidebar";
+```
+
+```tsx file=../../registry/examples/sidebar-example.tsx#L167-L266
+
+```
 
 ## See Also
 

--- a/src/pages/ui/skeleton.mdx
+++ b/src/pages/ui/skeleton.mdx
@@ -30,16 +30,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import { Skeleton } from "~/components/ui/skeleton";
-```
-
-```tsx showLineNumbers
-<Skeleton class="h-[20px] w-[100px] rounded-full" />
-```
-
 ## Examples
 
 Here are the source code of all the examples from the preview page:

--- a/src/pages/ui/slider.mdx
+++ b/src/pages/ui/slider.mdx
@@ -24,16 +24,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import { Slider } from "~/components/ui/slider";
-```
-
-```tsx showLineNumbers
-<Slider defaultValue={[33]} maxValue={100} step={1} />
-```
-
 ## Props
 
 The Slider component uses Kobalte's Slider primitive under the hood. Here are the main props:

--- a/src/pages/ui/sonner.mdx
+++ b/src/pages/ui/sonner.mdx
@@ -30,46 +30,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import { Toaster } from "~/components/ui/sonner";
-import { toast } from "solid-sonner";
-```
-
-Add the `Toaster` component to your app root:
-
-```tsx showLineNumbers title="App.tsx"
-import { Toaster } from "~/components/ui/sonner";
-
-export default function App() {
-  return (
-    <>
-      <Toaster />
-      {/* Your app content */}
-    </>
-  );
-}
-```
-
-Then use the `toast` function to show notifications:
-
-```tsx showLineNumbers
-toast("Event has been created");
-
-// With description
-toast("Event has been created", {
-  description: "Monday, January 3rd at 6:00pm",
-});
-
-// Different variants
-toast.success("Success!");
-toast.error("Error!");
-toast.warning("Warning!");
-toast.info("Information");
-toast.loading("Loading...");
-```
-
 ## Examples
 
 Here are the source code of all the examples from the preview page:

--- a/src/pages/ui/spinner.mdx
+++ b/src/pages/ui/spinner.mdx
@@ -24,16 +24,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import { Spinner } from "~/components/ui/spinner";
-```
-
-```tsx showLineNumbers
-<Spinner />
-```
-
 ## Customization
 
 You can replace the default spinner icon with any other icon by editing the `Spinner` component.

--- a/src/pages/ui/switch.mdx
+++ b/src/pages/ui/switch.mdx
@@ -30,16 +30,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import { Switch } from "~/components/ui/switch";
-```
-
-```tsx showLineNumbers
-<Switch />
-```
-
 ## Examples
 
 Here are the source code of all the examples from the preview page:

--- a/src/pages/ui/table.mdx
+++ b/src/pages/ui/table.mdx
@@ -24,43 +24,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import {
-  Table,
-  TableBody,
-  TableCaption,
-  TableCell,
-  TableFooter,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "~/components/ui/table";
-```
-
-```tsx showLineNumbers
-<Table>
-  <TableCaption>A list of your recent invoices.</TableCaption>
-  <TableHeader>
-    <TableRow>
-      <TableHead class="w-[100px]">Invoice</TableHead>
-      <TableHead>Status</TableHead>
-      <TableHead>Method</TableHead>
-      <TableHead class="text-right">Amount</TableHead>
-    </TableRow>
-  </TableHeader>
-  <TableBody>
-    <TableRow>
-      <TableCell class="font-medium">INV001</TableCell>
-      <TableCell>Paid</TableCell>
-      <TableCell>Credit Card</TableCell>
-      <TableCell class="text-right">$250.00</TableCell>
-    </TableRow>
-  </TableBody>
-</Table>
-```
-
 ## Data Table
 
 You can use the `<Table />` component to build more complex data tables. Combine it with [@tanstack/solid-table](https://tanstack.com/table/v8) to create tables with sorting, filtering and pagination.

--- a/src/pages/ui/tabs.mdx
+++ b/src/pages/ui/tabs.mdx
@@ -24,23 +24,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "~/components/ui/tabs";
-```
-
-```tsx showLineNumbers
-<Tabs defaultValue="account" class="w-[400px]">
-  <TabsList>
-    <TabsTrigger value="account">Account</TabsTrigger>
-    <TabsTrigger value="password">Password</TabsTrigger>
-  </TabsList>
-  <TabsContent value="account">Make changes to your account here.</TabsContent>
-  <TabsContent value="password">Change your password here.</TabsContent>
-</Tabs>
-```
-
 ## Examples
 
 Here are the source code of all the examples from the preview page:

--- a/src/pages/ui/textarea.mdx
+++ b/src/pages/ui/textarea.mdx
@@ -24,16 +24,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import { Textarea } from "~/components/ui/textarea";
-```
-
-```tsx showLineNumbers
-<Textarea placeholder="Type your message here." />
-```
-
 ## Examples
 
 Here are the source code of all the examples from the preview page:

--- a/src/pages/ui/toggle-group.mdx
+++ b/src/pages/ui/toggle-group.mdx
@@ -30,20 +30,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import { ToggleGroup, ToggleGroupItem } from "~/components/ui/toggle-group";
-```
-
-```tsx showLineNumbers
-<ToggleGroup defaultValue="a">
-  <ToggleGroupItem value="a">A</ToggleGroupItem>
-  <ToggleGroupItem value="b">B</ToggleGroupItem>
-  <ToggleGroupItem value="c">C</ToggleGroupItem>
-</ToggleGroup>
-```
-
 ## Examples
 
 Here are the source code of all the examples from the preview page:

--- a/src/pages/ui/toggle.mdx
+++ b/src/pages/ui/toggle.mdx
@@ -30,16 +30,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import { Toggle } from "~/components/ui/toggle";
-```
-
-```tsx showLineNumbers
-<Toggle>Toggle</Toggle>
-```
-
 ## Examples
 
 Here are the source code of all the examples from the preview page:

--- a/src/pages/ui/tooltip.mdx
+++ b/src/pages/ui/tooltip.mdx
@@ -30,25 +30,6 @@ Copy and paste the following code into your project.
 
 ```
 
-## Usage
-
-```tsx
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "~/components/ui/tooltip";
-```
-
-```tsx showLineNumbers
-<Tooltip>
-  <TooltipTrigger>Hover</TooltipTrigger>
-  <TooltipContent>
-    <p>Add to library</p>
-  </TooltipContent>
-</Tooltip>
-```
-
 ## Examples
 
 Here are the source code of all the examples from the preview page:


### PR DESCRIPTION
## Summary

This PR standardizes the documentation structure across all 56 UI component documentation files by:

- **Removing `## Usage` sections** from all component documentation
- **Adding missing `## Examples` sections** to components that lacked them
- **Ensuring consistent documentation structure**: Installation → Examples

## Changes Made

### Usage Section Removal (56 files)

All component documentation files in `src/pages/ui/*.mdx` had their `## Usage` sections removed. The Usage sections typically contained:
- Import statements
- Basic usage code snippets

These were redundant since the Examples section provides more comprehensive, real-world usage patterns.

### Examples Sections Added (5 files)

The following components were missing Examples sections and have been updated:

| Component | Examples Added |
|-----------|----------------|
| `chart.mdx` | Area Chart, Bar Chart, Line Chart, Pie Chart, Radar Chart |
| `sidebar.mdx` | Basic sidebar with navigation |
| `sidebar-floating.mdx` | Floating variant example |
| `sidebar-icon.mdx` | Icon collapsible variant example |
| `sidebar-inset.mdx` | Inset variant example |

## Why These Changes?

The documentation now follows a cleaner, more consistent structure:

1. **Before**: `Installation → Usage → Examples` (redundant Usage section)
2. **After**: `Installation → Examples` (streamlined)

The Examples section provides complete, copy-pasteable code snippets that reference the actual example files in the registry, making the Usage section unnecessary duplication.

## Files Changed

- **56 files modified** in `src/pages/ui/`
- **+289 insertions, -1,326 deletions** (net reduction of 1,037 lines)

## Validation

- ✅ All `## Usage` sections removed (verified via grep)
- ✅ All 56 files now have `## Examples` sections
- ✅ Documentation structure is consistent across all components

---

This PR was written using [Vibe Kanban](https://vibekanban.com)