### PR TITLE
Small doc fix

### DIFF
--- a/src/pages/docs/zaidan-agent.mdx
+++ b/src/pages/docs/zaidan-agent.mdx
@@ -58,7 +58,7 @@ The agent generates component code, examples, and documentation that integrate w
 - **Live preview** — See your transformed components rendered in the Zaidan UI
 - **Customizer access** — Test components against different themes, colors, fonts, and radius values using the built-in customizer
 - **Iterative workflow** — Review the generated code, tweak it, re-run the agent, and see updates in real time
-- **Easy Contribution** - Zaidan create commits and PR for you, so when you're ready to publish, just push the PR and we'll review it
+- **Easy Contribution** - Zaidan creates commits and PRs for you, so when you're ready to publish, just push the PR and we'll review it.
 
 ## Commands
 

--- a/src/pages/docs/zaidan-agent.mdx
+++ b/src/pages/docs/zaidan-agent.mdx
@@ -58,7 +58,7 @@ The agent generates component code, examples, and documentation that integrate w
 - **Live preview** — See your transformed components rendered in the Zaidan UI
 - **Customizer access** — Test components against different themes, colors, fonts, and radius values using the built-in customizer
 - **Iterative workflow** — Review the generated code, tweak it, re-run the agent, and see updates in real time
-- **Easy Contribution** - Zaidan create commits and PR for you, so when you're ready to publish, just push the PR and we''l review it
+- **Easy Contribution** - Zaidan create commits and PR for you, so when you're ready to publish, just push the PR and we'll review it
 
 ## Commands
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved wording under “Why clone Zaidan?” — corrected subject-verb agreement, pluralized “PRs,” fixed a stray apostrophe, and added a final period to the explanatory sentence. This is a minor, text-only documentation edit to improve clarity and grammar.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->