### PR TITLE
feat: sync scroll-area from shadcn

### DIFF
--- a/src/pages/shadcn/kobalte/scroll-area.mdx
+++ b/src/pages/shadcn/kobalte/scroll-area.mdx
@@ -1,0 +1,50 @@
+---
+title: Scroll Area
+slug: scroll-area
+description: Augments native scroll functionality for custom, cross-browser styling.
+---
+
+# Scroll Area
+
+Augments native scroll functionality for custom, cross-browser styling.
+
+## Installation
+
+### CLI
+
+```package-dlx
+shadcn@latest add @zaidan/scroll-area
+```
+
+### Manual
+
+Copy and paste the following code into your project.
+
+```tsx file=../../../registry/kobalte/ui/scroll-area.tsx showLineNumbers
+
+```
+
+## Examples
+
+Here are the source code of all the examples from the preview page:
+
+### Vertical
+
+```tsx
+import { ScrollArea } from "~/components/ui/scroll-area";
+import { Separator } from "~/components/ui/separator";
+```
+
+```tsx file=../../../registry/kobalte/examples/shadcn/scroll-area-example.tsx#L33-L51
+
+```
+
+### Horizontal
+
+```tsx
+import { ScrollArea, ScrollBar } from "~/components/ui/scroll-area";
+```
+
+```tsx file=../../../registry/kobalte/examples/shadcn/scroll-area-example.tsx#L53-L81
+
+```

--- a/src/registry/kobalte/examples/shadcn/scroll-area-example.tsx
+++ b/src/registry/kobalte/examples/shadcn/scroll-area-example.tsx
@@ -6,7 +6,7 @@ import { Separator } from "@/registry/kobalte/ui/separator";
 
 const tags = Array.from({ length: 50 }).map((_, i, a) => `v1.2.0-beta.${a.length - i}`);
 
-const works = [
+const artworks = [
   {
     artist: "Ornella Binni",
     art: "https://images.unsplash.com/photo-1465869185982-5a1a7522cbcb?auto=format&fit=crop&w=300&q=80",
@@ -55,14 +55,14 @@ function ScrollAreaHorizontal() {
     <Example title="Horizontal">
       <ScrollArea class="mx-auto w-full max-w-96 rounded-md style-luma:rounded-2xl border p-4">
         <div class="flex gap-4">
-          <For each={works}>
+          <For each={artworks}>
             {(artwork) => (
               <figure class="shrink-0">
                 <div class="overflow-hidden rounded-md">
                   <img
                     src={artwork.art}
                     alt={`Photo by ${artwork.artist}`}
-                    class="aspect-[3/4] h-fit w-fit object-cover"
+                    class="aspect-3/4 h-fit w-fit object-cover"
                     width={300}
                     height={400}
                   />

--- a/src/registry/kobalte/examples/shadcn/scroll-area-example.tsx
+++ b/src/registry/kobalte/examples/shadcn/scroll-area-example.tsx
@@ -1,0 +1,81 @@
+/** biome-ignore-all lint/a11y/noRedundantAlt: <example file> */
+import { For } from "solid-js";
+import { Example, ExampleWrapper } from "@/components/example";
+import { ScrollArea, ScrollBar } from "@/registry/kobalte/ui/scroll-area";
+import { Separator } from "@/registry/kobalte/ui/separator";
+
+const tags = Array.from({ length: 50 }).map((_, i, a) => `v1.2.0-beta.${a.length - i}`);
+
+const works = [
+  {
+    artist: "Ornella Binni",
+    art: "https://images.unsplash.com/photo-1465869185982-5a1a7522cbcb?auto=format&fit=crop&w=300&q=80",
+  },
+  {
+    artist: "Tom Byrom",
+    art: "https://images.unsplash.com/photo-1548516173-3cabfa4607e9?auto=format&fit=crop&w=300&q=80",
+  },
+  {
+    artist: "Vladimir Malyav",
+    art: "https://images.unsplash.com/photo-1494337480532-3725c85fd2ab?auto=format&fit=crop&w=300&q=80",
+  },
+] as const;
+
+export default function ScrollAreaExample() {
+  return (
+    <ExampleWrapper>
+      <ScrollAreaVertical />
+      <ScrollAreaHorizontal />
+    </ExampleWrapper>
+  );
+}
+
+function ScrollAreaVertical() {
+  return (
+    <Example title="Vertical">
+      <ScrollArea class="mx-auto h-72 w-48 rounded-md style-luma:rounded-2xl border">
+        <div class="p-4">
+          <h4 class="mb-4 font-medium text-sm leading-none">Tags</h4>
+          <For each={tags}>
+            {(tag) => (
+              <>
+                <div class="text-sm">{tag}</div>
+                <Separator class="my-2" />
+              </>
+            )}
+          </For>
+        </div>
+      </ScrollArea>
+    </Example>
+  );
+}
+
+function ScrollAreaHorizontal() {
+  return (
+    <Example title="Horizontal">
+      <ScrollArea class="mx-auto w-full max-w-96 rounded-md style-luma:rounded-2xl border p-4">
+        <div class="flex gap-4">
+          <For each={works}>
+            {(artwork) => (
+              <figure class="shrink-0">
+                <div class="overflow-hidden rounded-md">
+                  <img
+                    src={artwork.art}
+                    alt={`Photo by ${artwork.artist}`}
+                    class="aspect-[3/4] h-fit w-fit object-cover"
+                    width={300}
+                    height={400}
+                  />
+                </div>
+                <figcaption class="pt-2 text-muted-foreground text-xs">
+                  Photo by <span class="font-semibold text-foreground">{artwork.artist}</span>
+                </figcaption>
+              </figure>
+            )}
+          </For>
+        </div>
+        <ScrollBar orientation="horizontal" />
+      </ScrollArea>
+    </Example>
+  );
+}

--- a/src/registry/kobalte/registry.json
+++ b/src/registry/kobalte/registry.json
@@ -470,6 +470,18 @@
       ]
     },
     {
+      "name": "scroll-area",
+      "type": "registry:ui",
+      "dependencies": [],
+      "registryDependencies": [],
+      "files": [
+        {
+          "path": "src/registry/kobalte/ui/scroll-area.tsx",
+          "type": "registry:ui"
+        }
+      ]
+    },
+    {
       "name": "select",
       "type": "registry:ui",
       "dependencies": ["@kobalte/core", "lucide-solid"],

--- a/src/registry/kobalte/ui/scroll-area.tsx
+++ b/src/registry/kobalte/ui/scroll-area.tsx
@@ -271,13 +271,15 @@ const ScrollBar = (rawProps: ScrollBarProps) => {
     // biome-ignore lint/a11y/useKeyWithClickEvents: <track click is a pointer-only convenience; keyboard users scroll via viewport>
     <div
       class={cn(
-        "absolute flex touch-none select-none p-px transition-opacity duration-150",
-        isVertical() && "top-0 right-0 h-full w-2.5",
-        !isVertical() && "bottom-0 left-0 h-2.5 w-full",
+        "absolute z-scroll-area-scrollbar flex touch-none select-none p-px transition-opacity duration-150",
+        isVertical() && "top-0 right-0",
+        !isVertical() && "bottom-0 left-0 w-full",
         !shown() && "pointer-events-none opacity-0",
         local.class,
       )}
       data-orientation={local.orientation}
+      data-horizontal={!isVertical() ? "" : undefined}
+      data-vertical={isVertical() ? "" : undefined}
       data-slot="scroll-area-scrollbar"
       onClick={handleTrackClick}
       ref={scrollbarRef}
@@ -285,7 +287,7 @@ const ScrollBar = (rawProps: ScrollBarProps) => {
     >
       {/* biome-ignore lint/a11y/noStaticElementInteractions: <custom scrollbar thumb — keyboard scroll is handled via the native viewport> */}
       <div
-        class="relative flex-1 cursor-grab rounded-full bg-border active:cursor-grabbing"
+        class="relative z-scroll-area-thumb flex-1 cursor-grab bg-border active:cursor-grabbing"
         data-slot="scroll-area-thumb"
         onMouseDown={handleThumbMouseDown}
         ref={thumbRef}

--- a/src/registry/kobalte/ui/scroll-area.tsx
+++ b/src/registry/kobalte/ui/scroll-area.tsx
@@ -1,0 +1,314 @@
+import {
+  type Accessor,
+  type ComponentProps,
+  createContext,
+  createSignal,
+  type JSX,
+  mergeProps,
+  onCleanup,
+  onMount,
+  splitProps,
+  useContext,
+} from "solid-js";
+
+import { cn } from "@/lib/utils";
+
+type ScrollAreaContextValue = {
+  viewportRef: Accessor<HTMLDivElement | undefined>;
+  contentRef: Accessor<HTMLDivElement | undefined>;
+  hovered: Accessor<boolean>;
+};
+
+const ScrollAreaContext = createContext<ScrollAreaContextValue | null>(null);
+
+const useScrollArea = () => {
+  const context = useContext(ScrollAreaContext);
+  if (!context) {
+    throw new Error("useScrollArea must be used within a <ScrollArea />");
+  }
+  return context;
+};
+
+type ScrollAreaProps = ComponentProps<"div"> & {
+  children?: JSX.Element;
+};
+
+const ScrollArea = (props: ScrollAreaProps) => {
+  const [local, others] = splitProps(props, ["class", "children", "onMouseEnter", "onMouseLeave"]);
+
+  let viewportRef: HTMLDivElement | undefined;
+  const [hovered, setHovered] = createSignal(false);
+
+  return (
+    <ScrollAreaContext.Provider
+      value={{
+        viewportRef: () => viewportRef,
+        contentRef: () => viewportRef,
+        hovered,
+      }}
+    >
+      {/* biome-ignore lint/a11y/noStaticElementInteractions: <hover tracking is a passive UI affordance — no keyboard equivalent needed since the inner viewport remains keyboard-scrollable> */}
+      <div
+        class={cn("relative", local.class)}
+        data-slot="scroll-area"
+        onMouseEnter={(e) => {
+          setHovered(true);
+          if (typeof local.onMouseEnter === "function") local.onMouseEnter(e);
+        }}
+        onMouseLeave={(e) => {
+          setHovered(false);
+          if (typeof local.onMouseLeave === "function") local.onMouseLeave(e);
+        }}
+        {...others}
+      >
+        <div
+          class="size-full overflow-auto rounded-[inherit] outline-none transition-[color,box-shadow] [-ms-overflow-style:none] [scrollbar-width:none] focus-visible:outline-1 focus-visible:ring-[3px] focus-visible:ring-ring/50 [&::-webkit-scrollbar]:hidden"
+          data-slot="scroll-area-viewport"
+          ref={viewportRef}
+        >
+          {local.children}
+        </div>
+        <ScrollBar />
+        <div data-slot="scroll-area-corner" />
+      </div>
+    </ScrollAreaContext.Provider>
+  );
+};
+
+type ScrollBarProps = ComponentProps<"div"> & {
+  orientation?: "vertical" | "horizontal";
+};
+
+const ScrollBar = (rawProps: ScrollBarProps) => {
+  const props = mergeProps({ orientation: "vertical" as const }, rawProps);
+  const [local, others] = splitProps(props, ["class", "orientation"]);
+
+  const context = useScrollArea();
+  const [thumbSize, setThumbSize] = createSignal(0);
+  const [thumbPosition, setThumbPosition] = createSignal(0);
+  const [isDragging, setIsDragging] = createSignal(false);
+  const [dragOffset, setDragOffset] = createSignal(0);
+  const [visible, setVisible] = createSignal(false);
+
+  let scrollbarRef: HTMLDivElement | undefined;
+  let thumbRef: HTMLDivElement | undefined;
+
+  const isVertical = () => local.orientation === "vertical";
+
+  const updateScrollbar = () => {
+    const viewport = context.viewportRef();
+    if (!viewport) return;
+
+    if (isVertical()) {
+      const ratio = viewport.clientHeight / viewport.scrollHeight;
+      const size = Math.max(ratio * 100, 10);
+      setThumbSize(size);
+      setVisible(ratio < 1);
+
+      const maxScrollTop = viewport.scrollHeight - viewport.clientHeight;
+      const scrollRatio = maxScrollTop > 0 ? viewport.scrollTop / maxScrollTop : 0;
+      const maxThumbPosition = 100 - size;
+      setThumbPosition(Math.min(scrollRatio * maxThumbPosition, maxThumbPosition));
+    } else {
+      const ratio = viewport.clientWidth / viewport.scrollWidth;
+      const size = Math.max(ratio * 100, 10);
+      setThumbSize(size);
+      setVisible(ratio < 1);
+
+      const maxScrollLeft = viewport.scrollWidth - viewport.clientWidth;
+      const scrollRatio = maxScrollLeft > 0 ? viewport.scrollLeft / maxScrollLeft : 0;
+      const maxThumbPosition = 100 - size;
+      setThumbPosition(Math.min(scrollRatio * maxThumbPosition, maxThumbPosition));
+    }
+  };
+
+  const handleScroll = () => {
+    if (!isDragging()) {
+      updateScrollbar();
+    }
+  };
+
+  const handleThumbMouseDown = (e: MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const viewport = context.viewportRef();
+    if (!viewport || !scrollbarRef || !thumbRef) return;
+
+    setIsDragging(true);
+
+    const thumbRect = thumbRef.getBoundingClientRect();
+    if (isVertical()) {
+      setDragOffset(e.clientY - thumbRect.top);
+    } else {
+      setDragOffset(e.clientX - thumbRect.left);
+    }
+  };
+
+  const handleMouseMove = (e: MouseEvent) => {
+    if (!isDragging()) return;
+    e.preventDefault();
+
+    const viewport = context.viewportRef();
+    if (!viewport || !scrollbarRef) return;
+
+    if (isVertical()) {
+      const scrollbarRect = scrollbarRef.getBoundingClientRect();
+      const scrollbarHeight = scrollbarRect.height;
+      const maxScrollTop = viewport.scrollHeight - viewport.clientHeight;
+
+      if (maxScrollTop <= 0) return;
+
+      const mousePositionInTrack = e.clientY - scrollbarRect.top - dragOffset();
+
+      const ratio = viewport.clientHeight / viewport.scrollHeight;
+      const computedThumbSize = Math.max(ratio * 100, 10);
+      const maxThumbPosition = 100 - computedThumbSize;
+
+      const thumbPositionPercent = Math.max(
+        0,
+        Math.min((mousePositionInTrack / scrollbarHeight) * 100, maxThumbPosition),
+      );
+
+      const scrollRatio = maxThumbPosition > 0 ? thumbPositionPercent / maxThumbPosition : 0;
+      const newScrollTop = scrollRatio * maxScrollTop;
+
+      viewport.scrollTop = newScrollTop;
+      setThumbPosition(thumbPositionPercent);
+    } else {
+      const scrollbarRect = scrollbarRef.getBoundingClientRect();
+      const scrollbarWidth = scrollbarRect.width;
+      const maxScrollLeft = viewport.scrollWidth - viewport.clientWidth;
+
+      if (maxScrollLeft <= 0) return;
+
+      const mousePositionInTrack = e.clientX - scrollbarRect.left - dragOffset();
+
+      const ratio = viewport.clientWidth / viewport.scrollWidth;
+      const computedThumbSize = Math.max(ratio * 100, 10);
+      const maxThumbPosition = 100 - computedThumbSize;
+
+      const thumbPositionPercent = Math.max(
+        0,
+        Math.min((mousePositionInTrack / scrollbarWidth) * 100, maxThumbPosition),
+      );
+
+      const scrollRatio = maxThumbPosition > 0 ? thumbPositionPercent / maxThumbPosition : 0;
+      const newScrollLeft = scrollRatio * maxScrollLeft;
+
+      viewport.scrollLeft = newScrollLeft;
+      setThumbPosition(thumbPositionPercent);
+    }
+  };
+
+  const handleMouseUp = () => {
+    setIsDragging(false);
+  };
+
+  const handleTrackClick = (e: MouseEvent) => {
+    if (!scrollbarRef || !thumbRef) return;
+    const viewport = context.viewportRef();
+    if (!viewport) return;
+
+    const rect = scrollbarRef.getBoundingClientRect();
+    const thumbRect = thumbRef.getBoundingClientRect();
+
+    if (isVertical()) {
+      const clickY = e.clientY - rect.top;
+      const thumbY = thumbRect.top - rect.top;
+      const thumbHeight = thumbRect.height;
+
+      if (clickY < thumbY) {
+        viewport.scrollTop -= viewport.clientHeight;
+      } else if (clickY > thumbY + thumbHeight) {
+        viewport.scrollTop += viewport.clientHeight;
+      }
+    } else {
+      const clickX = e.clientX - rect.left;
+      const thumbX = thumbRect.left - rect.left;
+      const thumbWidth = thumbRect.width;
+
+      if (clickX < thumbX) {
+        viewport.scrollLeft -= viewport.clientWidth;
+      } else if (clickX > thumbX + thumbWidth) {
+        viewport.scrollLeft += viewport.clientWidth;
+      }
+    }
+  };
+
+  onMount(() => {
+    const viewport = context.viewportRef();
+    if (!viewport) return;
+
+    updateScrollbar();
+
+    viewport.addEventListener("scroll", handleScroll);
+
+    const resizeObserver = new ResizeObserver(() => {
+      updateScrollbar();
+    });
+
+    const content = context.contentRef();
+    if (content) {
+      resizeObserver.observe(content);
+    }
+    resizeObserver.observe(viewport);
+
+    document.addEventListener("mousemove", handleMouseMove);
+    document.addEventListener("mouseup", handleMouseUp);
+
+    onCleanup(() => {
+      viewport.removeEventListener("scroll", handleScroll);
+      resizeObserver.disconnect();
+      document.removeEventListener("mousemove", handleMouseMove);
+      document.removeEventListener("mouseup", handleMouseUp);
+    });
+  });
+
+  const shown = () => visible() && (context.hovered() || isDragging());
+
+  return (
+    // biome-ignore lint/a11y/noStaticElementInteractions: <custom scrollbar — keyboard scroll is handled via the native viewport>
+    // biome-ignore lint/a11y/useKeyWithClickEvents: <track click is a pointer-only convenience; keyboard users scroll via viewport>
+    <div
+      class={cn(
+        "absolute flex touch-none select-none p-px transition-opacity duration-150",
+        isVertical() && "top-0 right-0 h-full w-2.5",
+        !isVertical() && "bottom-0 left-0 h-2.5 w-full",
+        !shown() && "pointer-events-none opacity-0",
+        local.class,
+      )}
+      data-orientation={local.orientation}
+      data-slot="scroll-area-scrollbar"
+      onClick={handleTrackClick}
+      ref={scrollbarRef}
+      {...others}
+    >
+      {/* biome-ignore lint/a11y/noStaticElementInteractions: <custom scrollbar thumb — keyboard scroll is handled via the native viewport> */}
+      <div
+        class="relative flex-1 cursor-grab rounded-full bg-border active:cursor-grabbing"
+        data-slot="scroll-area-thumb"
+        onMouseDown={handleThumbMouseDown}
+        ref={thumbRef}
+        style={{
+          ...(isVertical()
+            ? {
+                position: "absolute",
+                top: `${thumbPosition()}%`,
+                height: `${thumbSize()}%`,
+                left: "0",
+                right: "0",
+              }
+            : {
+                position: "absolute",
+                left: `${thumbPosition()}%`,
+                width: `${thumbSize()}%`,
+                top: "0",
+                bottom: "0",
+              }),
+        }}
+      />
+    </div>
+  );
+};
+
+export { ScrollArea, ScrollBar };

--- a/src/registry/kobalte/ui/scroll-area.tsx
+++ b/src/registry/kobalte/ui/scroll-area.tsx
@@ -49,7 +49,7 @@ const ScrollArea = (props: ScrollAreaProps) => {
     >
       {/* biome-ignore lint/a11y/noStaticElementInteractions: <hover tracking is a passive UI affordance — no keyboard equivalent needed since the inner viewport remains keyboard-scrollable> */}
       <div
-        class={cn("relative", local.class)}
+        class={cn("relative overflow-clip", local.class)}
         data-slot="scroll-area"
         onMouseEnter={(e) => {
           setHovered(true);
@@ -272,14 +272,16 @@ const ScrollBar = (rawProps: ScrollBarProps) => {
     <div
       class={cn(
         "absolute z-scroll-area-scrollbar flex touch-none select-none p-px transition-opacity duration-150",
-        isVertical() && "top-0 right-0",
-        !isVertical() && "bottom-0 left-0 w-full",
-        !shown() && "pointer-events-none opacity-0",
+        {
+          "top-0 right-0": isVertical(),
+          "bottom-0 left-0 w-full": !isVertical(),
+          "pointer-events-none opacity-0": !shown(),
+        },
         local.class,
       )}
       data-orientation={local.orientation}
-      data-horizontal={!isVertical() ? "" : undefined}
-      data-vertical={isVertical() ? "" : undefined}
+      data-horizontal={!isVertical()}
+      data-vertical={isVertical()}
       data-slot="scroll-area-scrollbar"
       onClick={handleTrackClick}
       ref={scrollbarRef}
@@ -295,17 +297,23 @@ const ScrollBar = (rawProps: ScrollBarProps) => {
           ...(isVertical()
             ? {
                 position: "absolute",
-                top: `${thumbPosition()}%`,
+                top:
+                  thumbPosition() === 0
+                    ? `calc(${thumbPosition()}% + 1px)`
+                    : `calc(${thumbPosition()}% - 1px)`,
                 height: `${thumbSize()}%`,
-                left: "0",
-                right: "0",
+                left: "1px",
+                right: "1px",
               }
             : {
                 position: "absolute",
-                left: `${thumbPosition()}%`,
+                left:
+                  thumbPosition() === 0
+                    ? `calc(${thumbPosition()}% + 1px)`
+                    : `calc(${thumbPosition()}% - 1px)`,
                 width: `${thumbSize()}%`,
-                top: "0",
-                bottom: "0",
+                top: "1px",
+                bottom: "1px",
               }),
         }}
       />


### PR DESCRIPTION
## Summary
- Synced `scroll-area` from shadcn into Zaidan kobalte registry as a custom SolidJS implementation (Kobalte/Corvu provide no scroll-area primitive).
- Inspired by the [binnodon/solid-ui reference](https://raw.githubusercontent.com/binnodon/solid-ui/refs/heads/feat/claude-assist/apps/docs/src/registry/ui/scroll-area.tsx).
- Components synced: `scroll-area`
- Components failed: none
- Components blocked: none
- Closes #173 

## Components

| Component | Transform | Review | Docs | Visual | QA | Notes |
|-----------|-----------|--------|------|--------|-----|-------|
| scroll-area | SUCCESS | WARN | SUCCESS | PASS | PASS | 4 minor warnings; 5/5 stories pass after auto-hide + horizontal-scroll fixes |

## Verification Results

| Check | Status | Details |
|-------|--------|---------|
| Registry validation | PASS | registry-manager audit clean — 100 items, 0 violations |
| Component files exist | PASS | 1/1 (`src/registry/kobalte/ui/scroll-area.tsx`) |
| MDX docs exist | PASS | 1/1 (`src/pages/shadcn/kobalte/scroll-area.mdx`) |
| Example files exist | PASS | 1/1 (`src/registry/kobalte/examples/shadcn/scroll-area-example.tsx`) |

## QA Results

| # | Story | Status |
|---|-------|--------|
| 1 | Vertical scrollbar appears on overflow + auto-hides on mouseleave | PASS |
| 2 | Horizontal scrollbar with native horizontal wheel scroll | PASS |
| 3 | Thumb is draggable for direct scroll control | PASS |
| 4 | data-slot attributes exposed for E2E selectors | PASS |
| 5 | Native scrollbars hidden, scrollability preserved | PASS |

Initial QA flagged two failures vs. the reference baseline; both fixed in this PR:
- **Auto-hide on mouseleave**: added `hovered` signal + `onMouseEnter`/`onMouseLeave` on the root, with `shown = visible && (hovered || isDragging)` controlling opacity.
- **Native horizontal scroll**: removed hardcoded inline `overflow-x: hidden` style and switched viewport class from `overflow-scroll` to `overflow-auto` so both axes scroll natively while custom scrollbars stay in sync.

## Test Plan
- [ ] Visit `/ui/scroll-area`; verify vertical and horizontal demos render
- [ ] Hover the vertical scroll-area, scroll the tags list, move cursor away — scrollbar fades out
- [ ] Hover the horizontal scroll-area, scroll with shift+wheel or trackpad — both content and thumb track
- [ ] Drag the vertical thumb — viewport scrolls; cursor shows grab/grabbing
- [ ] Confirm \`data-slot\` attributes (\`scroll-area\`, \`scroll-area-viewport\`, \`scroll-area-scrollbar\`, \`scroll-area-thumb\`, \`scroll-area-corner\`) are present in the DOM
- [ ] Run \`bun run r:build:kobalte\` and confirm \`public/r/kobalte/scroll-area.json\` builds clean

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR syncs the `scroll-area` component into the Zaidan Kobalte registry as a hand-rolled SolidJS implementation (no Kobalte/Corvu primitive exists), featuring auto-hide scrollbars, drag-to-scroll, track-click page navigation, and a `hovered` signal for the fade-out effect. Two functional bugs flagged in prior review threads remain open in the current code: `contentRef` aliasing `viewportRef` (ResizeObserver won't detect inner-content size changes) and `handleMouseUp` not calling `updateScrollbar()` (thumb/viewport desync if the browser clamps a `scrollTop`/`scrollLeft` assignment during drag).

<h3>Confidence Score: 4/5</h3>

Safe to merge for basic use cases; two known P1 bugs from prior review threads remain unresolved and should be addressed before wider adoption.

Score is capped at 4 by the two unresolved P1 issues from previous review threads (contentRef aliasing and post-drag desync). All other findings in this pass are P2.

src/registry/kobalte/ui/scroll-area.tsx — the core implementation where the unresolved P1 bugs live.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/registry/kobalte/ui/scroll-area.tsx | New custom scroll-area implementation with drag, auto-hide, and track-click; has two unresolved P1 bugs from prior review threads (contentRef aliasing, missing updateScrollbar after drag) plus a P2 onClick override issue. |
| src/registry/kobalte/examples/shadcn/scroll-area-example.tsx | Adds vertical and horizontal scroll-area demo examples; straightforward and correct. |
| src/registry/kobalte/registry.json | Adds scroll-area registry entry with correct type and file path, no issues. |
| src/pages/shadcn/kobalte/scroll-area.mdx | New MDX documentation page for scroll-area with CLI/manual install instructions and inline example snippets; no issues. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User
    participant SA as ScrollArea (root)
    participant VP as Viewport div
    participant SB as ScrollBar
    participant DOC as document

    U->>SA: onMouseEnter
    SA->>SB: hovered = true (via context)
    SB->>SB: shown = visible && (hovered || isDragging) → opacity 1

    U->>VP: wheel scroll
    VP->>SB: scroll event → handleScroll()
    SB->>SB: updateScrollbar() → setThumbPosition / setThumbSize

    U->>SB: mousedown on thumb
    SB->>SB: setIsDragging(true), record dragOffset

    U->>DOC: mousemove
    DOC->>SB: handleMouseMove()
    SB->>VP: viewport.scrollTop = newScrollTop
    VP-->>SB: scroll event fires → handleScroll() bails (isDragging=true)
    SB->>SB: setThumbPosition(computed)

    U->>DOC: mouseup
    DOC->>SB: handleMouseUp()
    SB->>SB: setIsDragging(false) [no updateScrollbar call]

    U->>SA: onMouseLeave
    SA->>SB: hovered = false
    SB->>SB: shown = false → opacity 0, pointer-events-none

    U->>SB: click on track (before/after thumb)
    SB->>SB: handleTrackClick()
    SB->>VP: scrollTop ± clientHeight
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fregistry%2Fkobalte%2Fui%2Fscroll-area.tsx%3A286-288%0A**%60onClick%3D%7BhandleTrackClick%7D%60%20silently%20overridden%20by%20%60%7B...others%7D%60**%0A%0A%60handleTrackClick%60%20is%20declared%20before%20the%20%60%7B...others%7D%60%20spread%2C%20so%20any%20consumer%20who%20passes%20an%20%60onClick%60%20prop%20to%20%60%3CScrollBar%3E%60%20will%20silently%20replace%20the%20internal%20page-scroll-on-track-click%20logic.%20Since%20%60ScrollBar%60%20exposes%20%60ComponentProps%3C%22div%22%3E%60%2C%20this%20is%20a%20reachable%20code%20path.%20Consider%20merging%20the%20handlers%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20onClick%3D%7B%28e%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20%20%20handleTrackClick%28e%29%3B%0A%20%20%20%20%20%20%20%20if%20%28typeof%20%28others%20as%20ScrollBarProps%29.onClick%20%3D%3D%3D%20%22function%22%29%0A%20%20%20%20%20%20%20%20%20%20%28others%20as%20ScrollBarProps%29.onClick!%28e%29%3B%0A%20%20%20%20%20%20%7D%7D%0A%20%20%20%20%20%20ref%3D%7BscrollbarRef%7D%0A%20%20%20%20%20%20%7B...others%7D%0A%60%60%60%0A%0AOr%20move%20%60onClick%60%20after%20the%20spread%20and%20compose%20manually%20%28e.g.%20with%20SolidJS's%20%60mergeProps%60%20handler%20merging%29.%0A%0A&repo=carere%2Fzaidan&pr=182&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/registry/kobalte/ui/scroll-area.tsx
Line: 286-288

Comment:
**`onClick={handleTrackClick}` silently overridden by `{...others}`**

`handleTrackClick` is declared before the `{...others}` spread, so any consumer who passes an `onClick` prop to `<ScrollBar>` will silently replace the internal page-scroll-on-track-click logic. Since `ScrollBar` exposes `ComponentProps<"div">`, this is a reachable code path. Consider merging the handlers:

```suggestion
      onClick={(e) => {
        handleTrackClick(e);
        if (typeof (others as ScrollBarProps).onClick === "function")
          (others as ScrollBarProps).onClick!(e);
      }}
      ref={scrollbarRef}
      {...others}
```

Or move `onClick` after the spread and compose manually (e.g. with SolidJS's `mergeProps` handler merging).

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: some minor tweak"](https://github.com/carere/zaidan/commit/1c84e29b900d03b9c3d153a49f40b784f3c537be) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29784746)</sub>

<!-- /greptile_comment -->