### PR TITLE
feat: add homepage hero, changelog page, and blue-dot update indicator

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -52,6 +52,7 @@
   "cSpell.words": [
     "Abatan",
     "adws",
+    "bento",
     "biomejs",
     "bunx",
     "carere",

--- a/src/components/bento-notch.tsx
+++ b/src/components/bento-notch.tsx
@@ -3,7 +3,10 @@ import { SolidJS } from "@/components/icons/solidjs";
 
 export function BentoNotch() {
   return (
-    <div class="fixed bottom-4 left-1/2 z-50 -translate-x-1/2 rounded border bg-background/80 px-6 py-2 shadow-lg backdrop-blur-sm">
+    <div
+      data-slot="bento-notch"
+      class="rounded border bg-background/80 px-6 py-2 shadow-lg backdrop-blur-sm"
+    >
       <div class="flex items-center gap-2 whitespace-nowrap font-medium text-muted-foreground text-sm">
         <span>Made by</span>
         <a

--- a/src/components/home-hero.tsx
+++ b/src/components/home-hero.tsx
@@ -1,0 +1,60 @@
+import { Link, useSearch } from "@tanstack/solid-router";
+import { ArrowRightIcon } from "lucide-solid";
+import { BentoNotch } from "@/components/bento-notch";
+import { LATEST_ANNOUNCEMENT } from "@/lib/config";
+import { Button } from "@/registry/kobalte/ui/button";
+
+export function HomeHero() {
+  const search = useSearch({ strict: false });
+
+  return (
+    <section
+      data-slot="home-hero"
+      class="relative flex w-full flex-col items-center gap-6 px-4 pt-4 pb-16 text-center lg:pt-6 lg:pb-24"
+    >
+      <Link
+        to={LATEST_ANNOUNCEMENT.href}
+        search={search()}
+        class="group inline-flex items-center gap-1.5 rounded-full border bg-muted px-3 py-1 font-medium text-muted-foreground text-xs transition-colors hover:bg-muted/80"
+      >
+        <span>{LATEST_ANNOUNCEMENT.label}</span>
+        <ArrowRightIcon class="size-3 transition-transform group-hover:translate-x-0.5" />
+      </Link>
+
+      <h1 class="max-w-3xl text-balance font-heading font-semibold text-3xl tracking-tight lg:text-5xl lg:leading-[1.1] lg:tracking-tighter">
+        A SolidJS Registry Inspired by Shadcn UI
+      </h1>
+
+      <p class="max-w-2xl text-balance text-base text-muted-foreground lg:text-lg">
+        Beautifully designed, accessible components built on Kobalte and Corvu. Copy, paste, and
+        ship — or pull them in via the shadcn CLI.
+      </p>
+
+      <div class="flex flex-wrap items-center justify-center gap-3">
+        <Button
+          as={Link}
+          to="/$slug"
+          //@ts-expect-error <Problem with kobalte typing polymorphic props>
+          params={{ slug: "installation" }}
+          //@ts-expect-error <Problem with kobalte typing polymorphic props>
+          search={search()}
+          size="lg"
+        >
+          Getting Started
+        </Button>
+        <Button
+          as={Link}
+          to="/ui/{-$slug}"
+          //@ts-expect-error <Problem with kobalte typing polymorphic props>
+          search={search()}
+          variant="outline"
+          size="lg"
+        >
+          View Components
+        </Button>
+      </div>
+
+      <BentoNotch />
+    </section>
+  );
+}

--- a/src/components/home-hero.tsx
+++ b/src/components/home-hero.tsx
@@ -1,23 +1,20 @@
-import { Link, useSearch } from "@tanstack/solid-router";
+import { Link } from "@tanstack/solid-router";
 import { ArrowRightIcon } from "lucide-solid";
 import { BentoNotch } from "@/components/bento-notch";
-import { LATEST_ANNOUNCEMENT } from "@/lib/config";
 import { Button } from "@/registry/kobalte/ui/button";
 
 export function HomeHero() {
-  const search = useSearch({ strict: false });
-
   return (
     <section
       data-slot="home-hero"
       class="relative flex w-full flex-col items-center gap-6 px-4 pt-4 pb-16 text-center lg:pt-6 lg:pb-24"
     >
       <Link
-        to={LATEST_ANNOUNCEMENT.href}
-        search={search()}
+        to="/$slug"
+        params={{ slug: "changelog" }}
         class="group inline-flex items-center gap-1.5 rounded-full border bg-muted px-3 py-1 font-medium text-muted-foreground text-xs transition-colors hover:bg-muted/80"
       >
-        <span>{LATEST_ANNOUNCEMENT.label}</span>
+        <span>Changelog page is live</span>
         <ArrowRightIcon class="size-3 transition-transform group-hover:translate-x-0.5" />
       </Link>
 
@@ -36,20 +33,11 @@ export function HomeHero() {
           to="/$slug"
           //@ts-expect-error <Problem with kobalte typing polymorphic props>
           params={{ slug: "installation" }}
-          //@ts-expect-error <Problem with kobalte typing polymorphic props>
-          search={search()}
-          size="lg"
+          size="sm"
         >
           Getting Started
         </Button>
-        <Button
-          as={Link}
-          to="/ui/{-$slug}"
-          //@ts-expect-error <Problem with kobalte typing polymorphic props>
-          search={search()}
-          variant="outline"
-          size="lg"
-        >
+        <Button as={Link} to="/ui/{-$slug}" variant="outline" size="sm">
           View Components
         </Button>
       </div>

--- a/src/components/home/index.tsx
+++ b/src/components/home/index.tsx
@@ -1,4 +1,3 @@
-import { Button } from "@/registry/kobalte/ui/button";
 import { FieldSeparator } from "@/registry/kobalte/ui/field";
 
 import AppearanceSettings from "./appearance-settings";
@@ -19,7 +18,7 @@ import SpinnerBadge from "./spinner-badge";
 
 export function RootComponents() {
   return (
-    <div class="theme-container mx-auto grid gap-8 py-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 xl:gap-6 2xl:gap-8">
+    <div class="theme-container mx-auto grid gap-10 py-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 xl:gap-8 2xl:gap-10">
       <div class="flex flex-col gap-6 *:[div]:w-full *:[div]:max-w-full">
         <FieldDemo />
       </div>
@@ -37,17 +36,6 @@ export function RootComponents() {
         <AppearanceSettings />
       </div>
       <div class="order-first flex flex-col gap-6 lg:hidden xl:order-last xl:flex *:[div]:w-full *:[div]:max-w-full">
-        <div class="flex flex-col items-center gap-3 rounded-lg border bg-card p-6">
-          <span class="text=2xl">Welcome to Zaidan</span>
-          <div class="flex items-center gap-2">
-            <Button as="a" href="/zaidan-agent" target="_top">
-              Zaidan Agent
-            </Button>
-            <Button as="a" href="/installation" target="_top" variant="outline">
-              Get Started
-            </Button>
-          </div>
-        </div>
         <NotionPromptForm />
         <ButtonGroupDemo />
         <FieldCheckbox />

--- a/src/components/item-explorer.tsx
+++ b/src/components/item-explorer.tsx
@@ -1,9 +1,8 @@
 import { Link, useSearch } from "@tanstack/solid-router";
 import { ChevronRightIcon } from "lucide-solid";
 import { For, mergeProps, Show, splitProps } from "solid-js";
-import { getEntries, isNew } from "@/lib/registry-entries";
+import { getEntries, hasUpdate } from "@/lib/registry-entries";
 import { cn } from "@/lib/utils";
-import { Badge } from "@/registry/kobalte/ui/badge";
 import {
   Collapsible,
   CollapsibleContent,
@@ -58,13 +57,13 @@ export function ItemExplorer(props: SidebarProps) {
                                 class="relative h-6.5 w-fit cursor-pointer overflow-visible border border-transparent font-normal text-[0.8rem] after:absolute after:inset-x-0 after:-inset-y-1 after:z-0 after:rounded-md data-[status=active]:border-accent data-[status=active]:bg-accent"
                               >
                                 {item.title}
-                                <Show when={isNew(item.slug)}>
-                                  <Badge
-                                    variant="default"
-                                    class="ml-1 rounded-sm px-1 py-0 font-mono text-[0.6rem]"
-                                  >
-                                    new
-                                  </Badge>
+                                <Show when={hasUpdate(item.slug, entry.kind)}>
+                                  <span
+                                    data-slot="update-indicator"
+                                    role="status"
+                                    aria-label="Has updates"
+                                    class="ml-1.5 size-1.5 shrink-0 rounded-full bg-sky-500"
+                                  />
                                 </Show>
                                 <span class="absolute inset-0 flex w-(--sidebar-width) bg-transparent" />
                               </SidebarMenuButton>

--- a/src/components/item-picker.tsx
+++ b/src/components/item-picker.tsx
@@ -10,9 +10,8 @@ import {
   Show,
   splitProps,
 } from "solid-js";
-import { getEntries, isNew } from "@/lib/registry-entries";
+import { getEntries, hasUpdate } from "@/lib/registry-entries";
 import { cn } from "@/lib/utils";
-import { Badge } from "@/registry/kobalte/ui/badge";
 import { Button } from "@/registry/kobalte/ui/button";
 import {
   Command,
@@ -98,13 +97,13 @@ export function ItemPicker(props: ComponentProps<"div">) {
                           }}
                         >
                           {item.title}
-                          <Show when={isNew(item.slug)}>
-                            <Badge
-                              variant="default"
-                              class="ml-1 rounded-sm px-1 py-0 font-mono text-[0.6rem]"
-                            >
-                              new
-                            </Badge>
+                          <Show when={hasUpdate(item.slug, entry.kind)}>
+                            <span
+                              data-slot="update-indicator"
+                              role="status"
+                              aria-label="Has updates"
+                              class="ml-1.5 size-1.5 shrink-0 rounded-full bg-sky-500"
+                            />
                           </Show>
                         </CommandItem>
                       )}

--- a/src/components/mdx-components.tsx
+++ b/src/components/mdx-components.tsx
@@ -17,7 +17,7 @@ export const sharedComponents = {
   h1: (props: ComponentProps<"h1">) => {
     return (
       <h1
-        class="relative mt-2 scroll-m-28 font-bold font-heading text-3xl tracking-tight [&>a]:no-underline"
+        class="relative mt-2 scroll-m-28 font-heading font-semibold text-4xl tracking-tight dark:text-[#D4D4D4] [&>a]:no-underline"
         {...props}
       />
     );
@@ -25,7 +25,7 @@ export const sharedComponents = {
   h2: (props: ComponentProps<"h2">) => {
     return (
       <h2
-        class="relative mt-10 scroll-m-28 font-heading font-medium text-xl tracking-tight first:mt-0 lg:mt-12 [&+.steps>h3]:mt-4! [&+.steps]:mt-0! [&+h3]:mt-6! [&+p]:mt-4! [&+]*:[code]:text-xl"
+        class="relative mt-10 mb-4 inline-flex scroll-m-28 font-heading font-semibold text-xl tracking-tight first:mt-0 lg:mt-12 dark:text-[#D4D4D4] [&+.steps>h3]:mt-4! [&+.steps]:mt-0! [&+h3]:mt-6! [&+p]:mt-4! [&+]*:[code]:text-xl"
         {...props}
       />
     );
@@ -33,7 +33,7 @@ export const sharedComponents = {
   h3: (props: ComponentProps<"h3">) => {
     return (
       <h3
-        class="relative mt-12 scroll-m-28 font-heading font-medium text-lg tracking-tight [&+p]:mt-4! *:[code]:text-xl"
+        class="relative mt-12 scroll-m-28 font-heading font-semibold text-lg tracking-tight dark:text-[#D4D4D4] [&+p]:mt-4! *:[code]:text-xl"
         {...props}
       />
     );
@@ -42,26 +42,36 @@ export const sharedComponents = {
   h4: (props: ComponentProps<"h4">) => {
     return (
       <h4
-        class="relative mt-8 scroll-m-28 font-heading font-medium text-base tracking-tight"
+        class="relative mt-8 scroll-m-28 font-heading font-semibold text-base tracking-tight dark:text-[#D4D4D4]"
         {...props}
       />
     );
   },
 
   h5: (props: ComponentProps<"h5">) => {
-    return <h5 class="relative mt-8 scroll-m-28 font-medium text-base tracking-tight" {...props} />;
+    return (
+      <h5
+        class="relative mt-8 scroll-m-28 font-semibold text-base tracking-tight dark:text-[#D4D4D4]"
+        {...props}
+      />
+    );
   },
 
   h6: (props: ComponentProps<"h6">) => {
-    return <h6 class="relative mt-8 scroll-m-28 font-medium text-base tracking-tight" {...props} />;
+    return (
+      <h6
+        class="relative mt-8 scroll-m-28 font-semibold text-base tracking-tight dark:text-[#D4D4D4]"
+        {...props}
+      />
+    );
   },
 
   a: (props: ComponentProps<"a">) => {
-    return <a class="font-medium underline-offset-4" {...props} />;
+    return <a class="underline-offset-4" {...props} />;
   },
 
   p: (props: ComponentProps<"p">) => {
-    return <p class="not-first:mt-6 text-sm leading-relaxed" {...props} />;
+    return <p class="not-first:mt-6 text-base leading-relaxed dark:text-[#D4D4D4]" {...props} />;
   },
 
   strong: (props: ComponentProps<"strong">) => {
@@ -77,7 +87,7 @@ export const sharedComponents = {
   },
 
   li: (props: ComponentProps<"li">) => {
-    return <li class="mt-2" {...props} />;
+    return <li class="mt-2 dark:text-[#D4D4D4]" {...props} />;
   },
 
   blockquote: (props: ComponentProps<"blockquote">) => {
@@ -290,7 +300,7 @@ export const sharedComponents = {
   TriangleAlert,
   CliButton,
   ChangelogEntry: (props: ParentProps) => (
-    <article data-slot="changelog-entry" class="mb-12 border-border border-b pb-12">
+    <article data-slot="changelog-entry" class="mb-12 border-border border-b pb-12 last:border-b-0">
       {props.children}
     </article>
   ),

--- a/src/components/mdx-components.tsx
+++ b/src/components/mdx-components.tsx
@@ -7,7 +7,7 @@ import { SolidStartLogo } from "@/components/icons/solid-start";
 import { SolidJS } from "@/components/icons/solidjs";
 import { SolidJsOff } from "@/components/icons/solidjs-off";
 import { Zaidan } from "@/components/icons/zaidan";
-import { getStorage } from "@/lib/utils";
+import { cn, getStorage } from "@/lib/utils";
 import { Alert, AlertDescription, AlertTitle } from "@/registry/kobalte/ui/alert";
 import { Button } from "@/registry/kobalte/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/registry/kobalte/ui/tabs";
@@ -289,6 +289,44 @@ export const sharedComponents = {
   CircleAlert,
   TriangleAlert,
   CliButton,
+  ChangelogEntry: (props: ParentProps) => (
+    <article data-slot="changelog-entry" class="mb-12 border-border border-b pb-12">
+      {props.children}
+    </article>
+  ),
+  MoreUpdates: (props: ParentProps) => {
+    const resolved = children(() => props.children);
+
+    return (
+      <Show when={resolved.toArray().length > 5}>
+        <section id="more-updates" data-slot="more-updates" class="mb-24 scroll-mt-24">
+          <h2 class="mb-6 font-heading font-semibold text-xl tracking-tight">More Updates</h2>
+          <div class="grid auto-rows-fr gap-3 sm:grid-cols-2">{resolved()}</div>
+        </section>
+      </Show>
+    );
+  },
+  UpdateCard: (props: { date: string; title: string; href?: string }) => {
+    const baseClass =
+      "flex w-full flex-col gap-1 rounded-xl bg-card px-4 py-3 text-card-foreground transition-colors hover:bg-card/80";
+
+    return (
+      <Show
+        when={props.href}
+        fallback={
+          <div data-slot="update-card" class={baseClass}>
+            <span class="text-muted-foreground text-xs">{props.date}</span>
+            <span class="font-medium text-sm">{props.title}</span>
+          </div>
+        }
+      >
+        <a data-slot="update-card" class={cn(baseClass, "no-underline")} href={props.href}>
+          <span class="text-muted-foreground text-xs">{props.date}</span>
+          <span class="font-medium text-sm">{props.title}</span>
+        </a>
+      </Show>
+    );
+  },
   PlannedBadge: () => (
     <span class="inline-flex items-center rounded-full border border-amber-500/30 bg-amber-500/10 px-2.5 py-0.5 font-medium text-amber-600 text-xs dark:text-amber-400">
       Planned

--- a/src/components/toc.tsx
+++ b/src/components/toc.tsx
@@ -20,7 +20,7 @@ function TocItems(props: { items: TocEntry; depth?: number }) {
           <a
             href={item.url}
             class={cn(
-              "inline-block py-1 text-muted-foreground text-sm transition-colors hover:text-foreground",
+              "inline-block py-1 text-muted-foreground text-xs transition-colors hover:text-foreground",
               {
                 "pl-0": depth() === 0,
                 "pl-4": depth() === 1,
@@ -50,7 +50,7 @@ export function TableOfContents(props: TableOfContentsProps) {
   return (
     <nav data-slot="toc" class={props.class} aria-label="Table of contents">
       <div class="pb-4">
-        <p class="mb-2 font-medium text-sm">On This Page</p>
+        <p class="mb-2 font-medium text-xs">On This Page</p>
         <ul class="space-y-1">
           <TocItems items={props.toc} />
         </ul>

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -236,7 +236,10 @@ export type UpdatedItem = {
  * its label in the sidebar and command palette. The list is maintained
  * manually — entries stay until the maintainer removes them.
  */
-export const UPDATED_ITEMS: UpdatedItem[] = [{ kind: "docs", slug: "changelog" }];
+export const UPDATED_ITEMS: UpdatedItem[] = [
+  { kind: "docs", slug: "changelog" },
+  { kind: "ui", slug: "scroll-area" },
+];
 
 /**
  * Announcement pill shown above the homepage hero. Update `label` + `href`

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -240,18 +240,3 @@ export const UPDATED_ITEMS: UpdatedItem[] = [
   { kind: "docs", slug: "changelog" },
   { kind: "ui", slug: "scroll-area" },
 ];
-
-/**
- * Announcement pill shown above the homepage hero. Update `label` + `href`
- * whenever a new announcement-worthy release ships; the rest of the homepage
- * picks it up automatically.
- */
-export type LatestAnnouncement = {
-  label: string;
-  href: string;
-};
-
-export const LATEST_ANNOUNCEMENT: LatestAnnouncement = {
-  label: "New: Changelog page is live",
-  href: "/changelog",
-};

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -220,7 +220,35 @@ export const PRIMITIVES: { name: Primitive; label: string }[] = [
 ];
 
 /**
- * Components flagged as new.
- * Slugs listed here render a `new` badge in the sidebar and command palette.
+ * Discriminated entry for the "has updates" indicator. Items listed in
+ * {@link UPDATED_ITEMS} render a small blue dot next to their label in the
+ * sidebar (`ItemExplorer`) and command palette (`ItemPicker`). The `kind`
+ * keeps the lookup unambiguous when the same slug exists across docs, ui,
+ * and blocks (e.g. a doc page named "button" vs the button component).
  */
-export const NEW_COMPONENTS: string[] = [];
+export type UpdatedItem = {
+  kind: "docs" | "ui" | "blocks";
+  slug: string;
+};
+
+/**
+ * Items flagged as recently updated. Each entry renders a blue dot next to
+ * its label in the sidebar and command palette. The list is maintained
+ * manually — entries stay until the maintainer removes them.
+ */
+export const UPDATED_ITEMS: UpdatedItem[] = [{ kind: "docs", slug: "changelog" }];
+
+/**
+ * Announcement pill shown above the homepage hero. Update `label` + `href`
+ * whenever a new announcement-worthy release ships; the rest of the homepage
+ * picks it up automatically.
+ */
+export type LatestAnnouncement = {
+  label: string;
+  href: string;
+};
+
+export const LATEST_ANNOUNCEMENT: LatestAnnouncement = {
+  label: "New: Changelog page is live",
+  href: "/changelog",
+};

--- a/src/lib/registry-entries.ts
+++ b/src/lib/registry-entries.ts
@@ -1,5 +1,5 @@
 import { blocks, docs, ui } from "@velite";
-import { NEW_COMPONENTS } from "@/lib/config";
+import { UPDATED_ITEMS, type UpdatedItem } from "@/lib/config";
 import type { FileRouteTypes } from "@/routeTree.gen";
 
 export type MergedItem = {
@@ -12,11 +12,12 @@ export type MergedItem = {
 export type Entry = {
   title: string;
   items: MergedItem[];
-  kind?: "ui" | "blocks";
+  kind: "docs" | "ui" | "blocks";
   route: FileRouteTypes["to"];
 };
 
-export const isNew = (slug: string) => NEW_COMPONENTS.includes(slug);
+export const hasUpdate = (slug: string, kind: UpdatedItem["kind"]) =>
+  UPDATED_ITEMS.some((item) => item.kind === kind && item.slug === slug);
 
 export function getAllBlocks(): MergedItem[] {
   return [...blocks].sort((a, b) => a.title.localeCompare(b.title));
@@ -33,6 +34,7 @@ export function getEntries(): Entry[] {
       items: docs
         .filter((d) => d.parent === undefined)
         .sort((a, b) => (a.order ?? Infinity) - (b.order ?? Infinity)),
+      kind: "docs",
       route: "/$slug",
     },
     {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -87,6 +87,10 @@ export type IframeMessage =
   | {
       type: "color-mode-sync";
       data: ColorMode;
+    }
+  | {
+      type: "iframe-height-sync";
+      data: number;
     };
 
 export type IframeMessageType = IframeMessage["type"];

--- a/src/pages/docs/changelog.mdx
+++ b/src/pages/docs/changelog.mdx
@@ -9,6 +9,8 @@ order: 7
 
 Latest updates and announcements.
 
+<ChangelogEntry>
+
 ## April 2026 - Changelog & Home Refresh
 
 We're introducing two changes to make Zaidan easier to follow at a glance.
@@ -21,6 +23,10 @@ The **homepage** has also been refreshed: a hero with quick access to the instal
 
 The sidebar and command palette now show a small **blue dot** next to any item that has updates worth noticing. The dot replaces the old `new` text badge and works for docs, UI components, and blocks alike.
 
+</ChangelogEntry>
+
+<ChangelogEntry>
+
 ## February 2026 - 1.0 Stable
 
 The first stable release of Zaidan ([1.0.0](https://github.com/carere/zaidan/releases/tag/1.0.0)) shipped in February, followed by a flurry of small fixes (1.0.1 → 1.0.5):
@@ -29,6 +35,10 @@ The first stable release of Zaidan ([1.0.0](https://github.com/carere/zaidan/rel
 - Fixed a first-render hydration bug that occasionally prevented JavaScript from booting on the first paint.
 - Restored dynamic page titles when navigating between component pages.
 - Patched the missing `lucide-solid` dependency on the `bazza-data-table-filter` block.
+
+</ChangelogEntry>
+
+<ChangelogEntry>
 
 ## February 2026 - Website Launch & Component Library
 
@@ -40,10 +50,12 @@ The Zaidan website went live with the `0.0.7` milestone, alongside the bulk of t
 - Style variants — **Vega**, **Nova**, **Lyra**, **Maia**, **Mira**, **Luma**, **Sera** — applied to the entire registry, not just isolated demos.
 - Persistent view mode (preview vs docs) and customizer state via cookie-backed storage.
 
-## More Updates
+</ChangelogEntry>
 
-- GitHub link in the header now displays the live star count.
-- Command palette: `Cmd+K` (or `Ctrl+K`) opens the page picker from anywhere on the site.
-- Bento home preview re-rendered live as the customizer changes — pick a font and watch every demo restyle.
-- Pre-release pipeline (knope) automates the conventional-commit changelog and version bumps.
-- Continuous quality-assurance workflow on every PR.
+<MoreUpdates>
+  <UpdateCard date="February 2026" title="GitHub Star Counter" />
+  <UpdateCard date="February 2026" title="Cmd+K Command Palette" />
+  <UpdateCard date="February 2026" title="Live Bento Reactivity" />
+  <UpdateCard date="February 2026" title="Knope Pre-Release Pipeline" />
+  <UpdateCard date="February 2026" title="Quality Assurance CI" />
+</MoreUpdates>

--- a/src/pages/docs/changelog.mdx
+++ b/src/pages/docs/changelog.mdx
@@ -1,0 +1,49 @@
+---
+title: "Changelog"
+description: "Latest updates and announcements for the Zaidan registry."
+slug: "changelog"
+order: 7
+---
+
+# Changelog
+
+Latest updates and announcements.
+
+## April 2026 - Changelog & Home Refresh
+
+We're introducing two changes to make Zaidan easier to follow at a glance.
+
+This page — the **Changelog** — replaces the old "scroll the git log" experience. Going forward, every meaningful release will land here as a short, themed entry. The auto-generated `CHANGELOG.md` at the repo root continues to live alongside our release tooling for those who want the full bullet-by-bullet history.
+
+The **homepage** has also been refreshed: a hero with quick access to the installation guide and the component library, and a small announcement badge so we can highlight what's new without burying it.
+
+### Blue dot indicator
+
+The sidebar and command palette now show a small **blue dot** next to any item that has updates worth noticing. The dot replaces the old `new` text badge and works for docs, UI components, and blocks alike.
+
+## February 2026 - 1.0 Stable
+
+The first stable release of Zaidan ([1.0.0](https://github.com/carere/zaidan/releases/tag/1.0.0)) shipped in February, followed by a flurry of small fixes (1.0.1 → 1.0.5):
+
+- Proper SEO metadata on every route (Open Graph image, Twitter cards, page-specific titles and descriptions).
+- Fixed a first-render hydration bug that occasionally prevented JavaScript from booting on the first paint.
+- Restored dynamic page titles when navigating between component pages.
+- Patched the missing `lucide-solid` dependency on the `bazza-data-table-filter` block.
+
+## February 2026 - Website Launch & Component Library
+
+The Zaidan website went live with the `0.0.7` milestone, alongside the bulk of the component library:
+
+- 50+ components ported from shadcn — Accordion, Alert, AlertDialog, Avatar, Badge, Breadcrumb, Button, ButtonGroup, Calendar, Card, Carousel, Chart, Checkbox, Collapsible, Combobox, Command, ContextMenu, Dialog, Drawer, DropdownMenu, Empty, Field, HoverCard, Input, InputGroup, InputOTP, Item, Kbd, Label, Menubar, NativeSelect, NavigationMenu, Pagination, Popover, Progress, RadioGroup, Resizable, ScrollArea, Select, Separator, Sheet, Sidebar, Skeleton, Slider, Sonner, Spinner, Switch, Table, Tabs, Textarea, Toggle, ToggleGroup, Tooltip — each with examples and documentation.
+- Live preview iframes per component, wired to a customizer that lets you pick base color, theme, font, radius, and style on the fly.
+- File-based routing via TanStack Solid Router; MDX content powered by Velite.
+- Style variants — **Vega**, **Nova**, **Lyra**, **Maia**, **Mira**, **Luma**, **Sera** — applied to the entire registry, not just isolated demos.
+- Persistent view mode (preview vs docs) and customizer state via cookie-backed storage.
+
+## More Updates
+
+- GitHub link in the header now displays the live star count.
+- Command palette: `Cmd+K` (or `Ctrl+K`) opens the page picker from anywhere on the site.
+- Bento home preview re-rendered live as the customizer changes — pick a font and watch every demo restyle.
+- Pre-release pipeline (knope) automates the conventional-commit changelog and version bumps.
+- Continuous quality-assurance workflow on every PR.

--- a/src/pages/docs/changelog.mdx
+++ b/src/pages/docs/changelog.mdx
@@ -7,11 +7,11 @@ order: 7
 
 # Changelog
 
-Latest updates and announcements.
+<span class="mt-2 mb-10 inline-flex text-sm text-muted-foreground">Latest updates and announcements.</span>
 
 <ChangelogEntry>
 
-## April 2026 - Changelog & Home Refresh
+## April 2026 - New Blocks
 
 We're introducing two changes to make Zaidan easier to follow at a glance.
 
@@ -19,15 +19,11 @@ This page — the **Changelog** — replaces the old "scroll the git log" experi
 
 The **homepage** has also been refreshed: a hero with quick access to the installation guide and the component library, and a small announcement badge so we can highlight what's new without burying it.
 
-### Blue dot indicator
-
-The sidebar and command palette now show a small **blue dot** next to any item that has updates worth noticing. The dot replaces the old `new` text badge and works for docs, UI components, and blocks alike.
-
 </ChangelogEntry>
 
 <ChangelogEntry>
 
-## February 2026 - 1.0 Stable
+## March 2026 - Zaidan Agent
 
 The first stable release of Zaidan ([1.0.0](https://github.com/carere/zaidan/releases/tag/1.0.0)) shipped in February, followed by a flurry of small fixes (1.0.1 → 1.0.5):
 
@@ -40,7 +36,7 @@ The first stable release of Zaidan ([1.0.0](https://github.com/carere/zaidan/rel
 
 <ChangelogEntry>
 
-## February 2026 - Website Launch & Component Library
+## February 2026 - Website Launch
 
 The Zaidan website went live with the `0.0.7` milestone, alongside the bulk of the component library:
 

--- a/src/routes/_website.index.tsx
+++ b/src/routes/_website.index.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, useRouter } from "@tanstack/solid-router";
 import { createEffect, onCleanup, onMount, untrack } from "solid-js";
+import { HomeHero } from "@/components/home-hero";
 import { createPageHead } from "@/lib/seo";
 import type { IframeMessage } from "@/lib/types";
 import { useColorMode } from "@/registry/kobalte/components/color-mode";
@@ -83,8 +84,14 @@ function RouteComponent() {
     );
 
   return (
-    <div class="relative flex h-full w-[calc(100svw-var(--spacing)*8)] flex-row overflow-hidden md:w-[calc(100svw-var(--spacing)*56)] lg:w-full">
-      <iframe ref={iframeRef} src={href()} class="z-10 size-full rounded-lg" title="Home Preview" />
+    <div class="no-scrollbar relative flex h-full w-[calc(100svw-var(--spacing)*8)] flex-col overflow-y-auto md:w-[calc(100svw-var(--spacing)*56)] lg:w-full">
+      <HomeHero />
+      <iframe
+        ref={iframeRef}
+        src={href()}
+        class="z-10 min-h-[700px] w-full flex-1 rounded-lg"
+        title="Home Preview"
+      />
     </div>
   );
 }

--- a/src/routes/_website.index.tsx
+++ b/src/routes/_website.index.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, useRouter } from "@tanstack/solid-router";
-import { createEffect, onCleanup, onMount, untrack } from "solid-js";
+import { createEffect, createSignal, onCleanup, onMount, untrack } from "solid-js";
 import { HomeHero } from "@/components/home-hero";
 import { createPageHead } from "@/lib/seo";
 import type { IframeMessage } from "@/lib/types";
@@ -22,9 +22,13 @@ function RouteComponent() {
   const search = Route.useSearch();
   const { colorMode } = useColorMode();
 
+  // Drives the iframe's height — set from messages posted by the iframe so
+  // the iframe sizes to its content and doesn't show an internal scrollbar.
+  const [iframeHeight, setIframeHeight] = createSignal(700);
+
   let iframeRef: HTMLIFrameElement | undefined;
 
-  // Handle forwarded keyboard shortcuts from iframe
+  // Handle forwarded keyboard shortcuts + height updates from iframe
   onMount(() => {
     const handleMessage = (event: MessageEvent<IframeMessage>) => {
       if (event.data.type === "dark-mode-forward") {
@@ -51,6 +55,8 @@ function RouteComponent() {
           cancelable: true,
         });
         document.dispatchEvent(syntheticEvent);
+      } else if (event.data.type === "iframe-height-sync") {
+        setIframeHeight(event.data.data);
       }
     };
 
@@ -89,7 +95,9 @@ function RouteComponent() {
       <iframe
         ref={iframeRef}
         src={href()}
-        class="z-10 min-h-[700px] w-full flex-1 rounded-lg"
+        style={{ height: `${iframeHeight()}px` }}
+        scrolling="no"
+        class="z-10 w-full shrink-0 rounded-lg"
         title="Home Preview"
       />
     </div>

--- a/src/routes/preview.home.tsx
+++ b/src/routes/preview.home.tsx
@@ -88,12 +88,34 @@ function PreviewComponent() {
       }
     };
 
+    // Notify the parent of the iframe document's content height so the
+    // parent can size the iframe to its content (no internal scroll).
+    const postHeight = () => {
+      if (window.parent && window.parent !== window) {
+        window.parent.postMessage({
+          type: "iframe-height-sync",
+          data: document.documentElement.scrollHeight,
+        } satisfies IframeMessage);
+      }
+    };
+
+    // Re-measure whenever the body resizes (theme/style/font/customizer
+    // changes can grow or shrink the bento).
+    const resizeObserver = new ResizeObserver(() => postHeight());
+    resizeObserver.observe(document.body);
+
+    // Initial measurement + recompute on viewport resize.
+    postHeight();
+    window.addEventListener("resize", postHeight);
+
     window.addEventListener("message", handleMessage);
     document.addEventListener("keydown", handleKeyDown);
 
     onCleanup(() => {
       window.removeEventListener("message", handleMessage);
+      window.removeEventListener("resize", postHeight);
       document.removeEventListener("keydown", handleKeyDown);
+      resizeObserver.disconnect();
       document.getElementById("design-system-theme-vars")?.remove();
     });
   });

--- a/src/routes/preview.home.tsx
+++ b/src/routes/preview.home.tsx
@@ -1,6 +1,5 @@
 import { createFileRoute } from "@tanstack/solid-router";
 import { createEffect, createMemo, createSignal, on, onCleanup, onMount, Show } from "solid-js";
-import { BentoNotch } from "@/components/bento-notch";
 import { RootComponents } from "@/components/home";
 import { FONTS, RADII } from "@/lib/config";
 import { buildRegistryTheme } from "@/lib/theme-utils";
@@ -203,7 +202,6 @@ function PreviewComponent() {
   return (
     <Show when={isReady()}>
       <RootComponents />
-      <BentoNotch />
     </Show>
   );
 }


### PR DESCRIPTION
## Summary

Three coordinated UI/content changes on the website surface, mirroring shadcn's docs site patterns:

- **Changelog page** — new `/changelog` MDX docs page (`order: 7`, slots after Roadmap in the sidebar) with a shadcn-style narrative format (themed `Month YYYY - Title` h2 entries + closing `More Updates` rollup). Seeded with three entries derived from the existing `CHANGELOG.md` history. The root `CHANGELOG.md` stays as-is (release-tooling artifact).
- **Blue-dot update indicator** — replaces the old `<Badge>new</Badge>` text in `ItemExplorer` and `ItemPicker` with a small blue dot (`bg-sky-500`). Driven by a single kind-aware `UPDATED_ITEMS` list in `src/lib/config.ts` so it now works for docs, ui, and blocks (not just components). `isNew(slug)` becomes `hasUpdate(slug, kind)`; `Entry.kind` is required and includes `"docs"`. On launch, only Changelog gets a dot.
- **Homepage hero** — restructures `/` with a hero section above the existing iframe: announcement pill (driven by a configurable `LATEST_ANNOUNCEMENT` constant), h1, subheading, two CTAs (Getting Started → `/installation`, View Components → `/ui`), and the `BentoNotch` moved inline below the buttons. The embedded "Welcome to Zaidan" card was removed from the bento and the grid loosened (`gap-10`/`xl:gap-8`). CTAs preserve customizer search params via `useSearch({ strict: false })`.
- Closes #189 

## Implementation notes

- The hero lives **outside** the iframe, so the bento keeps its live theme reactivity (postMessage plumbing untouched). The hero itself doesn't react to the customizer — the maintainer flagged this tradeoff as acceptable for simpler architecture.
- `LATEST_ANNOUNCEMENT` defaults to `"New: Changelog page is live" → /changelog`. Update `label`/`href` whenever a new announcement-worthy release ships.
- The `<span>` blue-dot uses `role=\"status\"` + `aria-label=\"Has updates\"` so Biome's a11y rule passes and screen readers get the info.
- Polymorphic `Button as={Link}` uses `@ts-expect-error` for params/search — same pattern already in `ItemExplorer` (Kobalte/TanStack Router type interop).

## Test plan

- [x] `/` shows announcement pill, h1, subheading, two CTAs, then bento with `BentoNotch` underneath the buttons
- [x] CTAs navigate to `/installation` and `/ui` and preserve customizer state (theme/font/radius/style survive the click)
- [x] Announcement pill links to `/changelog`
- [x] Sidebar \"Getting Started\" group lists 7 items in order: Installation, Customization, Dark Mode, Zaidan Agent, FAQ, Roadmap, **Changelog**
- [x] A small **blue dot** appears next to \"Changelog\" in both the sidebar and the Cmd+K command palette
- [x] `/changelog` renders the seeded entries with proper h1/h2/h3 styling and a final \"More Updates\" bullet list
- [x] No \"Welcome to Zaidan\" card visible inside the bento
- [x] Top spacing between the nav and the hero is tight (`pt-4 lg:pt-6`); bottom spacing before the bento stays generous (`pb-16 lg:pb-24`)
- [x] `bun biome check src/` clean
- [x] `bunx tsc --noEmit` clean (after `bunx velite build` for codegen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a homepage hero section, a `/changelog` MDX page, and replaces the text `new` badge with a kind-aware blue-dot update indicator. The iframe height-sync mechanism (ResizeObserver inside the preview frame posting `scrollHeight` to the parent) is well-structured with proper cleanup. The discriminated `UPDATED_ITEMS` list is a clean improvement over the previous flat slug array.

Two previously-flagged P1s remain unresolved in the current head: the `scroll-area` entry in `UPDATED_ITEMS` (not mentioned in the PR as newly updated) and the `MoreUpdates` guard using `> 5` against exactly 5 seed `UpdateCard` children — both make that section permanently invisible.

<h3>Confidence Score: 4/5</h3>

Safe to merge after resolving the two leftover P1s from prior review threads (scroll-area in UPDATED_ITEMS and the MoreUpdates > 5 threshold).

Two P1 findings from previous threads are still present in the head commit — the spurious scroll-area update indicator and the MoreUpdates section that can never render. No new P0/P1 issues were found. The iframe height-sync and the hasUpdate refactor are correct.

src/lib/config.ts (scroll-area leftover) and src/components/mdx-components.tsx (MoreUpdates threshold; global h2 inline-flex)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/config.ts | Adds UpdatedItem type and UPDATED_ITEMS list; scroll-area entry is a leftover from testing (flagged in prior thread) |
| src/components/mdx-components.tsx | Adds ChangelogEntry/MoreUpdates/UpdateCard components; MoreUpdates never renders with the current 5-item seed (> 5 threshold, flagged prior); h2 changed to inline-flex globally |
| src/components/home-hero.tsx | New hero section; announcement pill and CTAs are hardcoded rather than config-driven as the PR description implies, but functional |
| src/routes/_website.index.tsx | Adds iframe height-sync signal and renders HomeHero above the iframe; cleanup is correct |
| src/routes/preview.home.tsx | Adds ResizeObserver + window resize listener to post scrollHeight to parent; cleanup handles all listeners and observer correctly |
| src/lib/registry-entries.ts | Replaces isNew/NEW_COMPONENTS with hasUpdate/UPDATED_ITEMS; Entry.kind is now required and includes docs |
| src/pages/docs/changelog.mdx | New MDX changelog page with 3 ChangelogEntry sections and 5 UpdateCard children; the MoreUpdates section never renders with exactly 5 items (flagged prior) |
| src/components/bento-notch.tsx | Removed fixed positioning and backdrop styling; BentoNotch is now inline inside HomeHero |
| src/components/home/index.tsx | Removes Welcome to Zaidan card and adjusts grid gap; clean removal |
| src/lib/types.ts | Adds iframe-height-sync message type to the IframeMessage discriminated union; correct |
| src/components/toc.tsx | TOC link text and header reduced from text-sm to text-xs; minor typographic tweak |
| .vscode/settings.json | Adds bento to cSpell word list; trivial |
| src/components/item-explorer.tsx | Replaces Badge new with blue-dot span; now calls hasUpdate with kind for proper scoping |
| src/components/item-picker.tsx | Same Badge-to-blue-dot replacement as ItemExplorer, consistent and correct |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Parent as _website.index.tsx
    participant Hero as HomeHero
    participant IFrame as preview.home iframe
    participant RO as ResizeObserver

    Parent->>Hero: render (outside iframe)
    Parent->>IFrame: src=/preview/home
    IFrame->>RO: observe(document.body)
    IFrame->>Parent: postMessage(iframe-height-sync, scrollHeight)
    Parent->>Parent: setIframeHeight(data)
    Parent->>IFrame: style.height = iframeHeight()px

    Note over IFrame,RO: On theme/font/radius change
    Parent->>IFrame: postMessage(design-system-params-sync)
    IFrame->>IFrame: re-render RootComponents
    RO->>IFrame: body resized
    IFrame->>Parent: postMessage(iframe-height-sync, newScrollHeight)
    Parent->>Parent: setIframeHeight(newData)
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fcomponents%2Fmdx-components.tsx%3A310%0A**%60inline-flex%60%20on%20%60h2%60%20is%20a%20global%20change%20affecting%20all%20docs%20pages**%0A%0AAdding%20%60inline-flex%60%20to%20the%20shared%20%60h2%60%20component%20means%20every%20MDX%20%60h2%60%20across%20the%20entire%20docs%20site%20is%20now%20sized%20to%20its%20content%20width%20instead%20of%20spanning%20the%20full%20block.%20This%20was%20added%20for%20the%20changelog's%20styled%20section%20headers%2C%20but%20it%20changes%20the%20visual%20behavior%20of%20headings%20on%20all%20other%20docs%20pages%20%28Installation%2C%20Customization%2C%20Dark%20Mode%2C%20etc.%29.%20Consider%20scoping%20this%20to%20a%20changelog-specific%20component%20or%20applying%20it%20only%20within%20a%20%60ChangelogEntry%60%20context%20rather%20than%20altering%20the%20shared%20heading%20primitive.%0A%0A&repo=carere%2Fzaidan&pr=192&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/components/mdx-components.tsx
Line: 310

Comment:
**`inline-flex` on `h2` is a global change affecting all docs pages**

Adding `inline-flex` to the shared `h2` component means every MDX `h2` across the entire docs site is now sized to its content width instead of spanning the full block. This was added for the changelog's styled section headers, but it changes the visual behavior of headings on all other docs pages (Installation, Customization, Dark Mode, etc.). Consider scoping this to a changelog-specific component or applying it only within a `ChangelogEntry` context rather than altering the shared heading primitive.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (5): Last reviewed commit: ["fix: some minor tweak"](https://github.com/carere/zaidan/commit/7c9ff18bf5557c98aa87eea95aae55a448e5f0a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29932303)</sub>

<!-- /greptile_comment -->