### PR TITLE
chore: release 1.1.0

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2.2.0

--- a/.github/workflows/quality-assurance.yml
+++ b/.github/workflows/quality-assurance.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version: latest
 
@@ -25,12 +25,13 @@ jobs:
 
       - name: Cache dist
         id: cache
-        uses: actions/cache@v5
+        uses: actions/cache@v5.0.5
         with:
           path: |
             dist
             .velite
-          key: ${{ runner.os }}-${{ hashFiles('vite.config.ts', 'velite.config.ts', 'src/**', 'public/**', 'bun.lockb') }}
+          key: ${{ runner.os }}-${{ hashFiles('vite.config.ts', 'velite.config.ts',
+            'src/**', 'public/**', 'bun.lockb') }}
 
       - name: Assuring build is working
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,19 +2,23 @@ name: Release
 
 on:
   pull_request:
-    types: [closed]
-    branches: [main]
+    types: [ closed ]
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:
   get-tag:
-    if: (github.head_ref == 'knope/pre-release' && github.event.pull_request.merged == true) || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
+    if: (github.head_ref == 'knope/pre-release' && github.event.pull_request.merged
+      == true) || (github.event_name == 'workflow_dispatch' && github.ref ==
+      'refs/heads/main')
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - name: "Get tag of latest draft release"
-        run: echo "tag_name=$(gh release list --repo ${{ github.repository }} --json 'isDraft,tagName' --jq '.[] | select(.isDraft) | .tagName')" >> $GITHUB_OUTPUT
+        run: echo "tag_name=$(gh release list --repo ${{ github.repository }} --json
+          'isDraft,tagName' --jq '.[] | select(.isDraft) | .tagName')" >>
+          $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ secrets.CI_WORKER_PAT }}
         id: get-tag
@@ -37,7 +41,7 @@ jobs:
       contents: write
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Set up Git user
         run: |
@@ -45,7 +49,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version: latest
 
@@ -68,7 +72,7 @@ jobs:
           git push origin ${{ needs.get-tag.outputs.tag_name }}
 
       - name: Deploy
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v3.15.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,187 @@
+## 1.1.0 (2026-05-01)
+
+### Features
+
+- add basic layout for zaidan website
+- finishing main layout
+- applying style-vega to body
+- using pathless route for layout
+- add velite to the mix
+- setup dynamic routing for docs & ui
+- adding new logo to zaidan website
+- add style provider to manage style selection on components preview
+- finishing styling and composing sidebars
+- add examples wrapper & tabs component
+- update ui component page with tabs for preview and docs
+- sync alert component
+- add mdx components
+- add view switcher
+- mdx configuration
+- add toc to doc pages
+- using vite loading to get mdx and fix scroll padding
+- add some components
+- improving some components
+- sync textarea component from shadcn
+- sync slider component from shadcn
+- sync switch component from shadcn
+- sync progress component from shadcn
+- sync spinner component from shadcn
+- sync toggle-group component from shadcn
+- sync label component from shadcn
+- sync item component from shadcn
+- sync field component from shadcn
+- sync input-group component from shadcn
+- sync input-otp component from shadcn
+- sync radio-group component from shadcn
+- sync empty component from shadcn
+- sync dropdown-menu component from shadcn
+- sync dialog component from shadcn
+- sync drawer component from shadcn (#26)
+- sync hover-card component from shadcn
+- sync resizable component from shadcn
+- sync popover component from shadcn (#14)
+- sync context-menu component from shadcn
+- update README
+- sync checkbox component from shadcn
+- sync select component from shadcn
+- sync pagination component from shadcn
+- sync navigation-menu component from shadcn
+- sync menubar component from shadcn
+- sync sonner component
+- sync combobox component
+- sync table component
+- sync command component
+- sync calendar component
+- sync chart component
+- sync accordion examples and documentation
+- add `Examples` section to alert documentation
+- sync alert-dialog examples and documentation
+- sync badge examples and documentation
+- sync aspect-ratio examples and documentation
+- sync avatar examples and documentation
+- finished alert-dialog test suite
+- sync avatar examples and documentation
+- sync breadcrumb examples and documentation
+- sync button examples and documentation
+- sync button-group examples and documentation
+- sync carousel examples and documentation
+- sync card examples and documentation
+- sync checkbox examples and documentation
+- sync collapsible examples and documentation
+- sync input-group examples and documentation
+- sync dialog examples and documentation
+- sync input examples and documentation
+- sync item examples and documentation
+- sync input-otp examples and documentation
+- sync hover-card examples and documentation
+- sync context-menu examples and documentation
+- sync empty examples and documentation
+- sync kbd examples and documentation
+- sync dropdown-menu examples and documentation
+- sync combobox examples and documentation
+- sync command examples and documentation
+- sync field examples and documentation
+- sync drawer examples and documentation
+- sync menubar examples and documentation
+- sync native-select examples and documentation
+- sync slider examples and documentation
+- sync progress examples and documentation
+- sync popover examples and documentation
+- sync sheet examples and documentation
+- sync radio-group examples and documentation
+- sync separator examples and documentation
+- sync pagination examples and documentation
+- sync label examples and documentation
+- sync select examples and documentation
+- sync resizable examples and documentation
+- sync navigation-menu examples and documentation
+- sync spinner examples and documentation
+- sync textarea examples and documentation
+- sync table examples and documentation
+- sync toggle-group examples and documentation
+- sync sonner examples and documentation
+- sync tabs examples and documentation
+- sync switch examples and documentation
+- sync skeleton examples and documentation
+- sync tooltip examples and documentation
+- sync toggle examples and documentation
+- sync toggle-group examples and documentation
+- sync calendar examples and documentation
+- move style application to body element with persistence
+- persist view mode in cookie storage
+- Add GitHub link with star count to header
+- implement command dialog item picker with Cmd+K shortcut
+- Add isolated component preview route
+- add all picker implementations
+- update regitry.json with all the components & dependencies
+- install vibe-kanban-web-companion
+- add weekNumbers, customCell, and monthYearSelection features
+- sync sidebar examples and documentation for all variants
+- add not found pages and loading skeletons
+- add badge group navigation for preview/docs toggle
+- add responsive to entire website
+- adding code_of_conduct and netlify badge
+- connect pickers to iframe preview via URL search params
+- finish sync between customizer & iframe
+- adding themes fron shadcn repo
+- Add dynamic theme CSS variable injection for preview iframe
+- implement random, reset, and lock mechanisms for pickers
+- add css styles to registry
+- finalizing styles.css (#128)
+- add proper registry config for themes, fonts, styles & radii (#134)
+- add ShareButton component
+- enhance not found pages with EmptyWithBorder pattern
+- add CLI command dialog button to header
+- add proper github link to website (#144)
+- add seo tags
+- add zaidan agent, new docs & new homepage
+- add luma and sera styles
+- sync scroll-area from shadcn
+- add font-heading design token and Heading font picker
+- sync shadcn theme update and add chart color picker
+- mirror shadcn 26-font catalog and section picker by type
+- add homepage hero, changelog page, and blue-dot update indicator
+- changelogs as velite collection
+- sync sortable from ReUI
+
+### Fixes
+
+- remove routeTree from linting & checking
+- remnove vite ignore & fix build
+- use sticky instead of fixed for positioning header
+- remove broken highlight in toc
+- update textarea-example
+- update slider example & component
+- update styles upon switch merge
+- use css variable to set progress value
+- controlled slider's value was tracked
+- use bun to access env variables
+- complete avatar component
+- inproving mobile responsive, still work to do
+- correct line number references in calendar documentation
+- Use SVG renderer with disabled emphasis for CSS variable support
+- update script to proper port allocation
+- update vite & playwright to use proper env var
+- using APP_PORT avoiding collision
+- accordion broken due to solidjs
+- item-explorer search params fix
+- quality assurance workflow
+- apllying good registry dependencies to items
+- get-tag jobs did not had the correct token
+- release workflow
+- update token with proper one
+- remove cache for release (#133)
+- add cloudflare account id (#136)
+- close dialog when AlertDialogAction is clicked
+- some ssr quircks to tackle
+- weird bug, button on first render cause unable to load js
+- add image og and better seo
+- title was not updated
+- head content does not update
+- add missing lucide-solid dependency to bazza-data-table-filter
+- updating lock file
+- docs + components + styles + router
+
 ## 1.0.5 (2026-02-28)
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,139 +2,6 @@
 
 ### Features
 
-- add basic layout for zaidan website
-- finishing main layout
-- applying style-vega to body
-- using pathless route for layout
-- add velite to the mix
-- setup dynamic routing for docs & ui
-- adding new logo to zaidan website
-- add style provider to manage style selection on components preview
-- finishing styling and composing sidebars
-- add examples wrapper & tabs component
-- update ui component page with tabs for preview and docs
-- sync alert component
-- add mdx components
-- add view switcher
-- mdx configuration
-- add toc to doc pages
-- using vite loading to get mdx and fix scroll padding
-- add some components
-- improving some components
-- sync textarea component from shadcn
-- sync slider component from shadcn
-- sync switch component from shadcn
-- sync progress component from shadcn
-- sync spinner component from shadcn
-- sync toggle-group component from shadcn
-- sync label component from shadcn
-- sync item component from shadcn
-- sync field component from shadcn
-- sync input-group component from shadcn
-- sync input-otp component from shadcn
-- sync radio-group component from shadcn
-- sync empty component from shadcn
-- sync dropdown-menu component from shadcn
-- sync dialog component from shadcn
-- sync drawer component from shadcn (#26)
-- sync hover-card component from shadcn
-- sync resizable component from shadcn
-- sync popover component from shadcn (#14)
-- sync context-menu component from shadcn
-- update README
-- sync checkbox component from shadcn
-- sync select component from shadcn
-- sync pagination component from shadcn
-- sync navigation-menu component from shadcn
-- sync menubar component from shadcn
-- sync sonner component
-- sync combobox component
-- sync table component
-- sync command component
-- sync calendar component
-- sync chart component
-- sync accordion examples and documentation
-- add `Examples` section to alert documentation
-- sync alert-dialog examples and documentation
-- sync badge examples and documentation
-- sync aspect-ratio examples and documentation
-- sync avatar examples and documentation
-- finished alert-dialog test suite
-- sync avatar examples and documentation
-- sync breadcrumb examples and documentation
-- sync button examples and documentation
-- sync button-group examples and documentation
-- sync carousel examples and documentation
-- sync card examples and documentation
-- sync checkbox examples and documentation
-- sync collapsible examples and documentation
-- sync input-group examples and documentation
-- sync dialog examples and documentation
-- sync input examples and documentation
-- sync item examples and documentation
-- sync input-otp examples and documentation
-- sync hover-card examples and documentation
-- sync context-menu examples and documentation
-- sync empty examples and documentation
-- sync kbd examples and documentation
-- sync dropdown-menu examples and documentation
-- sync combobox examples and documentation
-- sync command examples and documentation
-- sync field examples and documentation
-- sync drawer examples and documentation
-- sync menubar examples and documentation
-- sync native-select examples and documentation
-- sync slider examples and documentation
-- sync progress examples and documentation
-- sync popover examples and documentation
-- sync sheet examples and documentation
-- sync radio-group examples and documentation
-- sync separator examples and documentation
-- sync pagination examples and documentation
-- sync label examples and documentation
-- sync select examples and documentation
-- sync resizable examples and documentation
-- sync navigation-menu examples and documentation
-- sync spinner examples and documentation
-- sync textarea examples and documentation
-- sync table examples and documentation
-- sync toggle-group examples and documentation
-- sync sonner examples and documentation
-- sync tabs examples and documentation
-- sync switch examples and documentation
-- sync skeleton examples and documentation
-- sync tooltip examples and documentation
-- sync toggle examples and documentation
-- sync toggle-group examples and documentation
-- sync calendar examples and documentation
-- move style application to body element with persistence
-- persist view mode in cookie storage
-- Add GitHub link with star count to header
-- implement command dialog item picker with Cmd+K shortcut
-- Add isolated component preview route
-- add all picker implementations
-- update regitry.json with all the components & dependencies
-- install vibe-kanban-web-companion
-- add weekNumbers, customCell, and monthYearSelection features
-- sync sidebar examples and documentation for all variants
-- add not found pages and loading skeletons
-- add badge group navigation for preview/docs toggle
-- add responsive to entire website
-- adding code_of_conduct and netlify badge
-- connect pickers to iframe preview via URL search params
-- finish sync between customizer & iframe
-- adding themes fron shadcn repo
-- Add dynamic theme CSS variable injection for preview iframe
-- implement random, reset, and lock mechanisms for pickers
-- add css styles to registry
-- finalizing styles.css (#128)
-- add proper registry config for themes, fonts, styles & radii (#134)
-- add ShareButton component
-- enhance not found pages with EmptyWithBorder pattern
-- add CLI command dialog button to header
-- add proper github link to website (#144)
-- add seo tags
-- add zaidan agent, new docs & new homepage
 - add luma and sera styles
 - sync scroll-area from shadcn
 - add font-heading design token and Heading font picker
@@ -146,39 +13,6 @@
 
 ### Fixes
 
-- remove routeTree from linting & checking
-- remnove vite ignore & fix build
-- use sticky instead of fixed for positioning header
-- remove broken highlight in toc
-- update textarea-example
-- update slider example & component
-- update styles upon switch merge
-- use css variable to set progress value
-- controlled slider's value was tracked
-- use bun to access env variables
-- complete avatar component
-- inproving mobile responsive, still work to do
-- correct line number references in calendar documentation
-- Use SVG renderer with disabled emphasis for CSS variable support
-- update script to proper port allocation
-- update vite & playwright to use proper env var
-- using APP_PORT avoiding collision
-- accordion broken due to solidjs
-- item-explorer search params fix
-- quality assurance workflow
-- apllying good registry dependencies to items
-- get-tag jobs did not had the correct token
-- release workflow
-- update token with proper one
-- remove cache for release (#133)
-- add cloudflare account id (#136)
-- close dialog when AlertDialogAction is clicked
-- some ssr quircks to tackle
-- weird bug, button on first render cause unable to load js
-- add image og and better seo
-- title was not updated
-- head content does not update
-- add missing lucide-solid dependency to bazza-data-table-filter
 - updating lock file
 - docs + components + styles + router
 
@@ -217,137 +51,12 @@
 ### Features
 
 - add seo tags
+- add zaidan agent, new docs & new homepage
 
 ## 0.0.7 (2026-02-03)
 
 ### Features
 
-- add basic layout for zaidan website
-- finishing main layout
-- applying style-vega to body
-- using pathless route for layout
-- add velite to the mix
-- setup dynamic routing for docs & ui
-- adding new logo to zaidan website
-- add style provider to manage style selection on components preview
-- finishing styling and composing sidebars
-- add examples wrapper & tabs component
-- update ui component page with tabs for preview and docs
-- sync alert component
-- add mdx components
-- add view switcher
-- mdx configuration
-- add toc to doc pages
-- using vite loading to get mdx and fix scroll padding
-- add some components
-- improving some components
-- sync textarea component from shadcn
-- sync slider component from shadcn
-- sync switch component from shadcn
-- sync progress component from shadcn
-- sync spinner component from shadcn
-- sync toggle-group component from shadcn
-- sync label component from shadcn
-- sync item component from shadcn
-- sync field component from shadcn
-- sync input-group component from shadcn
-- sync input-otp component from shadcn
-- sync radio-group component from shadcn
-- sync empty component from shadcn
-- sync dropdown-menu component from shadcn
-- sync dialog component from shadcn
-- sync drawer component from shadcn (#26)
-- sync hover-card component from shadcn
-- sync resizable component from shadcn
-- sync popover component from shadcn (#14)
-- sync context-menu component from shadcn
-- update README
-- sync checkbox component from shadcn
-- sync select component from shadcn
-- sync pagination component from shadcn
-- sync navigation-menu component from shadcn
-- sync menubar component from shadcn
-- sync sonner component
-- sync combobox component
-- sync table component
-- sync command component
-- sync calendar component
-- sync chart component
-- sync accordion examples and documentation
-- add `Examples` section to alert documentation
-- sync alert-dialog examples and documentation
-- sync badge examples and documentation
-- sync aspect-ratio examples and documentation
-- sync avatar examples and documentation
-- finished alert-dialog test suite
-- sync avatar examples and documentation
-- sync breadcrumb examples and documentation
-- sync button examples and documentation
-- sync button-group examples and documentation
-- sync carousel examples and documentation
-- sync card examples and documentation
-- sync checkbox examples and documentation
-- sync collapsible examples and documentation
-- sync input-group examples and documentation
-- sync dialog examples and documentation
-- sync input examples and documentation
-- sync item examples and documentation
-- sync input-otp examples and documentation
-- sync hover-card examples and documentation
-- sync context-menu examples and documentation
-- sync empty examples and documentation
-- sync kbd examples and documentation
-- sync dropdown-menu examples and documentation
-- sync combobox examples and documentation
-- sync command examples and documentation
-- sync field examples and documentation
-- sync drawer examples and documentation
-- sync menubar examples and documentation
-- sync native-select examples and documentation
-- sync slider examples and documentation
-- sync progress examples and documentation
-- sync popover examples and documentation
-- sync sheet examples and documentation
-- sync radio-group examples and documentation
-- sync separator examples and documentation
-- sync pagination examples and documentation
-- sync label examples and documentation
-- sync select examples and documentation
-- sync resizable examples and documentation
-- sync navigation-menu examples and documentation
-- sync spinner examples and documentation
-- sync textarea examples and documentation
-- sync table examples and documentation
-- sync toggle-group examples and documentation
-- sync sonner examples and documentation
-- sync tabs examples and documentation
-- sync switch examples and documentation
-- sync skeleton examples and documentation
-- sync tooltip examples and documentation
-- sync toggle examples and documentation
-- sync toggle-group examples and documentation
-- sync calendar examples and documentation
-- move style application to body element with persistence
-- persist view mode in cookie storage
-- Add GitHub link with star count to header
-- implement command dialog item picker with Cmd+K shortcut
-- Add isolated component preview route
-- add all picker implementations
-- update regitry.json with all the components & dependencies
-- install vibe-kanban-web-companion
-- add weekNumbers, customCell, and monthYearSelection features
-- sync sidebar examples and documentation for all variants
-- add not found pages and loading skeletons
-- add badge group navigation for preview/docs toggle
-- add responsive to entire website
-- adding code_of_conduct and netlify badge
-- connect pickers to iframe preview via URL search params
-- finish sync between customizer & iframe
-- adding themes fron shadcn repo
-- Add dynamic theme CSS variable injection for preview iframe
-- implement random, reset, and lock mechanisms for pickers
-- add css styles to registry
-- finalizing styles.css (#128)
 - add proper registry config for themes, fonts, styles & radii (#134)
 - add ShareButton component
 - enhance not found pages with EmptyWithBorder pattern
@@ -356,34 +65,14 @@
 
 ### Fixes
 
-- remove routeTree from linting & checking
-- remnove vite ignore & fix build
-- use sticky instead of fixed for positioning header
-- remove broken highlight in toc
-- update textarea-example
-- update slider example & component
-- update styles upon switch merge
-- use css variable to set progress value
-- controlled slider's value was tracked
-- use bun to access env variables
-- complete avatar component
-- inproving mobile responsive, still work to do
-- correct line number references in calendar documentation
-- Use SVG renderer with disabled emphasis for CSS variable support
-- update script to proper port allocation
-- update vite & playwright to use proper env var
-- using APP_PORT avoiding collision
-- accordion broken due to solidjs
-- item-explorer search params fix
-- quality assurance workflow
-- apllying good registry dependencies to items
+- applying good registry dependencies to items
 - get-tag jobs did not had the correct token
 - release workflow
 - update token with proper one
 - remove cache for release (#133)
 - add cloudflare account id (#136)
 - close dialog when AlertDialogAction is clicked
-- some ssr quircks to tackle
+- some ssr quirks to tackle
 
 ## 0.0.6 (2026-02-03)
 
@@ -407,7 +96,7 @@
 
 ### Fixes
 
-- apllying good registry dependencies to items
+- applying good registry dependencies to items
 
 ## 0.0.2 (2026-02-01)
 
@@ -524,7 +213,7 @@
 - implement command dialog item picker with Cmd+K shortcut
 - Add isolated component preview route
 - add all picker implementations
-- update regitry.json with all the components & dependencies
+- update registry.json with all the components & dependencies
 - install vibe-kanban-web-companion
 - add weekNumbers, customCell, and monthYearSelection features
 - sync sidebar examples and documentation for all variants
@@ -534,7 +223,7 @@
 - adding code_of_conduct and netlify badge
 - connect pickers to iframe preview via URL search params
 - finish sync between customizer & iframe
-- adding themes fron shadcn repo
+- adding themes from shadcn repo
 - Add dynamic theme CSS variable injection for preview iframe
 - implement random, reset, and lock mechanisms for pickers
 - add css styles to registry
@@ -543,7 +232,7 @@
 ### Fixes
 
 - remove routeTree from linting & checking
-- remnove vite ignore & fix build
+- remove vite ignore & fix build
 - use sticky instead of fixed for positioning header
 - remove broken highlight in toc
 - update textarea-example
@@ -553,7 +242,7 @@
 - controlled slider's value was tracked
 - use bun to access env variables
 - complete avatar component
-- inproving mobile responsive, still work to do
+- improving mobile responsive, still work to do
 - correct line number references in calendar documentation
 - Use SVG renderer with disabled emphasis for CSS variable support
 - update script to proper port allocation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zaidan",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "Zaidan is a ShadCn registry for SolidJs",
   "homepage": "https://github.com/carere/zaidan",
   "bugs": "https://github.com/carere/zaidan/issues",


### PR DESCRIPTION
Changes shipped with the release:

## Features

- add luma and sera styles
- sync scroll-area from shadcn
- add font-heading design token and Heading font picker
- sync shadcn theme update and add chart color picker
- mirror shadcn 26-font catalog and section picker by type
- add homepage hero, changelog page, and blue-dot update indicator
- changelogs as velite collection
- sync sortable from ReUI

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is a standard `1.1.0` release PR that bumps `package.json`, prepends the release entry to `CHANGELOG.md`, fixes several historical typos in the changelog, and pins all GitHub Actions to exact patch versions (`checkout@v6.0.2`, `setup-bun@v2.2.0`, `cache@v5.0.5`, `wrangler-action@v3.15.0`) for reproducibility. No application logic is changed.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — all changes are mechanical (version bump, changelog, action pin).

No functional code is changed. The action version upgrades are explicit and intentional, and the changelog/version bump are consistent with each other. No P0/P1 findings.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/pre-release.yml | Pins `actions/checkout` to exact version `v6.0.2` for reproducibility; no functional logic changes. |
| .github/workflows/quality-assurance.yml | Pins all action versions to exact semver tags (`checkout@v6.0.2`, `setup-bun@v2.2.0`, `cache@v5.0.5`); reformats long `key` string across two lines; no functional changes. |
| .github/workflows/release.yml | Pins action versions (`checkout@v6.0.2`, `setup-bun@v2.2.0`, `wrangler-action@v3.15.0`); reformats long `if` and `run` expressions for readability; no functional changes. |
| CHANGELOG.md | Prepends the 1.1.0 release section; fixes multiple typos in historical entries (`applying`, `improving`, `remove`, `from`, `registry`); removes the verbose per-commit feature list from the 0.0.7 section. |
| package.json | Bumps package version from `1.0.5` to `1.1.0` to match the new CHANGELOG entry. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    PR[PR merged into main or workflow_dispatch] --> GT[get-tag job: Find latest draft release tag]
    GT --> RJ[release job]
    RJ --> CO[checkout v6.0.2]
    CO --> GC[Set up Git user]
    GC --> BUN[setup-bun v2.2.0]
    BUN --> INSTALL[bun install]
    INSTALL --> BUILD[bun run build]
    BUILD --> PUSH[git tag and push]
    PUSH --> DEPLOY[Deploy via wrangler-action v3.15.0]

    PRQA[PR opened or push] --> QAJ[quality-assurance job]
    QAJ --> QACO[checkout v6.0.2]
    QACO --> QABU[setup-bun v2.2.0]
    QABU --> CACHE{cache-hit via cache v5.0.5}
    CACHE -->|miss| QABUILD[bun run build]
    CACHE -->|hit| SKIP[Skip build]
```

<sub>Reviews (3): Last reviewed commit: ["chore: update workflow deps"](https://github.com/carere/zaidan/commit/404c9735c1503731951ec890f79c981944a5e16e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30511445)</sub>

<!-- /greptile_comment -->