### PR TITLE
fix(select): scroll to selected item when opening long lists

### DIFF
--- a/src/registry/kobalte/ui/select.tsx
+++ b/src/registry/kobalte/ui/select.tsx
@@ -105,9 +105,13 @@ type SelectContentProps<T extends ValidComponent = "div"> = PolymorphicProps<
 
 const SelectContent = <T extends ValidComponent = "div">(props: SelectContentProps<T>) => {
   const [local, others] = splitProps(props as SelectContentProps, ["class"]);
+  let contentRef: HTMLElement | undefined;
   return (
     <SelectPrimitive.Portal>
       <SelectPrimitive.Content
+        ref={(el) => {
+          contentRef = el;
+        }}
         class={cn(
           "relative isolate z-50 z-menu-target z-select-content max-h-80 min-w-32 origin-(--kb-select-content-transform-origin) overflow-y-auto overflow-x-hidden",
           local.class,
@@ -115,7 +119,7 @@ const SelectContent = <T extends ValidComponent = "div">(props: SelectContentPro
         data-slot="select-content"
         {...others}
       >
-        <SelectPrimitive.Listbox class="m-0 p-1" />
+        <SelectPrimitive.Listbox class="m-0 p-1" scrollRef={() => contentRef} />
       </SelectPrimitive.Content>
     </SelectPrimitive.Portal>
   );


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes automatic scrolling to the selected item when a `Select` dropdown opens with a long list. Previously, `SelectPrimitive.Listbox` had no `scrollRef` and would default to scrolling within the listbox itself rather than the actual scrollable container (`SelectPrimitive.Content`).

- A `ref` callback captures the `SelectPrimitive.Content` DOM element and passes it as an `Accessor<HTMLElement | undefined>` to `SelectPrimitive.Listbox`'s `scrollRef` prop, which is the correct Kobalte API for directing automatic scroll-to-selected behavior to an outer scrollable container.
- The change is minimal and scoped entirely to `select.tsx`, with no impact on other components or behaviors.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a small, targeted fix that wires up an existing Kobalte API correctly.

The ref is captured on the correct scrollable container (SelectPrimitive.Content, which carries overflow-y-auto), and () => contentRef is a valid Accessor<HTMLElement | undefined> as expected by Kobalte's scrollRef prop. SolidJS guarantees the parent ref callback fires before the child listbox mounts, so contentRef is always populated by the time Kobalte reads it. No existing behavior is changed — the prop was simply absent before.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/registry/kobalte/ui/select.tsx | Adds a ref to SelectContent and passes it as scrollRef to SelectListbox so Kobalte scrolls to the selected item on open; the API usage matches Kobalte docs and the implementation is correct. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant SelectTrigger
    participant SelectContent
    participant SelectListbox

    User->>SelectTrigger: click (open)
    SelectTrigger->>SelectContent: mount (Portal)
    Note over SelectContent: ref callback sets contentRef
    SelectContent->>SelectListbox: render with scrollRef
    SelectListbox->>SelectContent: scrollRef() → HTMLElement
    SelectListbox->>SelectContent: scrollIntoView(selectedItem)
    Note over SelectContent: overflowY:auto container scrolls to selected item
```

<sub>Reviews (2): Last reviewed commit: ["fix(select): scroll to selected item whe..."](https://github.com/carere/zaidan/commit/e86fffb393c2ef66e63215e31555ad7eec71248f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33872706)</sub>

<!-- /greptile_comment -->