### PR TITLE
fix: scroll to selected item when opening select

### DIFF
--- a/.github/workflows/quality-assurance.yml
+++ b/.github/workflows/quality-assurance.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - "**"
+  pull_request:
+    branches:
+      - main
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   static-test:

--- a/src/registry/kobalte/ui/select.tsx
+++ b/src/registry/kobalte/ui/select.tsx
@@ -105,9 +105,11 @@ type SelectContentProps<T extends ValidComponent = "div"> = PolymorphicProps<
 
 const SelectContent = <T extends ValidComponent = "div">(props: SelectContentProps<T>) => {
   const [local, others] = splitProps(props as SelectContentProps, ["class"]);
+  let contentRef: HTMLElement | undefined;
   return (
     <SelectPrimitive.Portal>
       <SelectPrimitive.Content
+        ref={(el) => (contentRef = el)}
         class={cn(
           "relative isolate z-50 z-menu-target z-select-content max-h-80 min-w-32 origin-(--kb-select-content-transform-origin) overflow-y-auto overflow-x-hidden",
           local.class,
@@ -115,7 +117,7 @@ const SelectContent = <T extends ValidComponent = "div">(props: SelectContentPro
         data-slot="select-content"
         {...others}
       >
-        <SelectPrimitive.Listbox class="m-0 p-1" />
+        <SelectPrimitive.Listbox class="m-0 p-1" scrollRef={() => contentRef} />
       </SelectPrimitive.Content>
     </SelectPrimitive.Portal>
   );


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the select component so that the currently selected item is scrolled into view when the dropdown opens, by capturing the content element's ref and passing it as `scrollRef` to kobalte's `SelectPrimitive.Listbox`. It also adds a `pull_request` trigger to the CI workflow so quality checks run on PRs targeting `main`.

- **`select.tsx`**: Introduces `contentRef` captured via the `ref` callback on `SelectPrimitive.Content`, then forwards it through `scrollRef={() => contentRef}` to `SelectPrimitive.Listbox` — the minimal, idiomatic kobalte fix for scroll-to-selected.
- **`quality-assurance.yml`**: Adds `pull_request` (opened, synchronize, reopened, ready_for_review) targeting `main`, but the pre-existing `push: branches: "**"` trigger still fires on the same commits, causing duplicate job runs per PR push.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the select fix is correct and minimal; the CI change is functional but wastes runner minutes on duplicate runs.

The select.tsx change is a clean, targeted fix: capturing the content ref and forwarding it via scrollRef is exactly how kobalte expects callers to direct its scroll-to-selected behaviour. The CI change works as intended but the push: ** trigger is still active, so every commit pushed to a PR branch fires both a push run and a pull_request: synchronize run, doubling CI cost for no gain.

.github/workflows/quality-assurance.yml — the dual-trigger overlap is worth resolving before the pattern becomes a habit across more workflows.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/registry/kobalte/ui/select.tsx | Wires up a ref to SelectContent and passes it as scrollRef to SelectPrimitive.Listbox so kobalte can scroll the selected item into view on open |
| .github/workflows/quality-assurance.yml | Adds a pull_request trigger on main alongside the existing push/** trigger, which causes duplicate job runs for every commit pushed to a PR branch |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant SelectTrigger
    participant SelectContent
    participant SelectListbox

    User->>SelectTrigger: Click / open
    SelectTrigger->>SelectContent: Mount (Portal)
    SelectContent->>SelectContent: ref callback sets contentRef
    SelectContent->>SelectListbox: "Mount with scrollRef(() => contentRef)"
    SelectListbox->>SelectListbox: scrollRef() returns contentRef (HTMLElement)
    SelectListbox->>SelectContent: scrollIntoView(selectedItem)
    SelectContent-->>User: Selected item visible in viewport
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fquality-assurance.yml%3A4-10%0A**Duplicate%20workflow%20runs%20on%20PR%20commits**%0A%0AThe%20existing%20%60push%3A%20branches%3A%20%22**%22%60%20trigger%20already%20fires%20whenever%20a%20commit%20is%20pushed%20to%20any%20branch%2C%20including%20PR%20branches%20targeting%20%60main%60.%20Adding%20the%20%60pull_request%60%20trigger%20with%20%60synchronize%60%20means%20every%20new%20commit%20on%20a%20PR%20will%20enqueue%20two%20identical%20runs%20%E2%80%94%20one%20from%20the%20%60push%60%20event%20and%20one%20from%20%60pull_request%3A%20synchronize%60%20%E2%80%94%20doubling%20CI%20minutes%20for%20no%20benefit.%0A%0AThe%20typical%20fix%20is%20to%20add%20a%20concurrency%20group%20that%20cancels%20in-flight%20runs%20for%20the%20same%20ref%2C%20or%20to%20scope%20the%20%60push%60%20trigger%20only%20to%20%60main%60%2Fprotected%20branches%20and%20rely%20on%20%60pull_request%60%20for%20feature%20branches.%0A%0A&repo=carere%2Fzaidan&pr=205&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/workflows/quality-assurance.yml:4-10
**Duplicate workflow runs on PR commits**

The existing `push: branches: "**"` trigger already fires whenever a commit is pushed to any branch, including PR branches targeting `main`. Adding the `pull_request` trigger with `synchronize` means every new commit on a PR will enqueue two identical runs — one from the `push` event and one from `pull_request: synchronize` — doubling CI minutes for no benefit.

The typical fix is to add a concurrency group that cancels in-flight runs for the same ref, or to scope the `push` trigger only to `main`/protected branches and rely on `pull_request` for feature branches.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: allow fork&#39;s PR to trigger static-t..."](https://github.com/carere/zaidan/commit/8c32723358b3a6c149a1a6fadd5580d1f999a922) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37016246)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->