### PR TITLE
test(validation): lock Cloudflare preview contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ public/r
 tests/browser/__screenshots__/
 
 # Coudflare
+.cloudflare/
 .wrangler/
 
 # Claude Code

--- a/scripts/install-cloudflare-playwright-deps.sh
+++ b/scripts/install-cloudflare-playwright-deps.sh
@@ -37,6 +37,7 @@ packages=(
   libxdamage1
   libxext6
   libxfixes3
+  libxi6
   libxkbcommon0
   libxrandr2
 )
@@ -49,3 +50,15 @@ apt-get "${apt_options[@]}" download "${packages[@]}"
 for archive in ./*.deb; do
   dpkg-deb --extract "${archive}" .
 done
+
+browser_binary="$(find "${PLAYWRIGHT_BROWSERS_PATH:-${HOME}/.cache/ms-playwright}" -type f -name chrome-headless-shell -print -quit)"
+
+if [[ -n "${browser_binary}" ]]; then
+  library_path="${library_root}/usr/lib/x86_64-linux-gnu"
+  missing_libraries="$(LD_LIBRARY_PATH="${library_path}:${LD_LIBRARY_PATH:-}" ldd "${browser_binary}" | awk '/not found/ { print $1 }')"
+
+  if [[ -n "${missing_libraries}" ]]; then
+    printf 'Missing Chromium libraries after provisioning:\n%s\n' "${missing_libraries}" >&2
+    exit 1
+  fi
+fi

--- a/scripts/install-cloudflare-playwright-deps.sh
+++ b/scripts/install-cloudflare-playwright-deps.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repository_root="$(pwd)"
+apt_root="${repository_root}/.cloudflare/apt"
+library_root="${repository_root}/.cloudflare/playwright-deps"
+
+mkdir -p \
+  "${apt_root}/lists/partial" \
+  "${apt_root}/cache/archives/partial" \
+  "${library_root}"
+
+apt_options=(
+  -o "Dir::State::Lists=${apt_root}/lists"
+  -o "Dir::Cache=${apt_root}/cache"
+  -o Debug::NoLocking=true
+)
+
+packages=(
+  libasound2t64
+  libatk-bridge2.0-0t64
+  libatk1.0-0t64
+  libatspi2.0-0t64
+  libcairo2
+  libcups2t64
+  libdbus-1-3
+  libdrm2
+  libgbm1
+  libglib2.0-0t64
+  libnspr4
+  libnss3
+  libpango-1.0-0
+  libx11-6
+  libxcb1
+  libxcomposite1
+  libxdamage1
+  libxext6
+  libxfixes3
+  libxkbcommon0
+  libxrandr2
+)
+
+apt-get "${apt_options[@]}" update
+
+cd "${library_root}"
+apt-get "${apt_options[@]}" download "${packages[@]}"
+
+for archive in ./*.deb; do
+  dpkg-deb --extract "${archive}" .
+done

--- a/tests/unit/toolchain-contract.test.ts
+++ b/tests/unit/toolchain-contract.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 describe("contributor validation", () => {
@@ -62,5 +62,36 @@ describe("contributor validation", () => {
     expect(workflow).toContain("'moon.yml'");
     expect(workflow).not.toContain("if: steps.cache.outputs.cache-hit != 'true'");
     expect(workflow).not.toMatch(/^\s+dist$/m);
+  });
+
+  it("keeps public branch previews isolated from production traffic", () => {
+    const wrangler = JSON.parse(
+      readFileSync(new URL("../../wrangler.jsonc", import.meta.url), "utf8"),
+    ) as { preview_urls?: boolean; workers_dev?: boolean };
+
+    expect(wrangler).toMatchObject({
+      preview_urls: true,
+      workers_dev: false,
+    });
+  });
+
+  it("retains existing GitHub validation and release files during expansion", () => {
+    const retainedFiles = [
+      ".github/workflows/quality-assurance.yml",
+      ".github/workflows/pre-release.yml",
+      ".github/workflows/release.yml",
+      "knope.toml",
+    ];
+
+    for (const file of retainedFiles) {
+      expect(existsSync(new URL(`../../${file}`, import.meta.url))).toBe(true);
+    }
+
+    const workflow = readFileSync(
+      new URL("../../.github/workflows/quality-assurance.yml", import.meta.url),
+      "utf8",
+    );
+
+    expect(workflow).toMatch(/^\s{2}static-test:/m);
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -28,6 +28,10 @@ export default defineConfig({
           name: "browser",
           include: ["tests/browser/**/*.test.tsx"],
           globalSetup: ["tests/browser/setup-built-app.ts"],
+          // Cloudflare Workers Builds share CPU while the built fixture and
+          // Chromium run together, so route hydration can exceed Vitest's
+          // 15-second default without indicating a failed assertion.
+          testTimeout: 60_000,
           browser: {
             enabled: true,
             headless: true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,10 @@
+import { resolve } from "node:path";
 import { playwright } from "@vitest/browser-playwright";
 import type { Frame } from "playwright";
 import solid from "vite-plugin-solid";
 import { defineConfig } from "vitest/config";
+
+const playwrightLibraryPath = resolve(".cloudflare/playwright-deps/usr/lib/x86_64-linux-gnu");
 
 export default defineConfig({
   resolve: { tsconfigPaths: true },
@@ -28,7 +31,16 @@ export default defineConfig({
           browser: {
             enabled: true,
             headless: true,
-            provider: playwright(),
+            provider: playwright({
+              launchOptions: {
+                env: {
+                  ...process.env,
+                  LD_LIBRARY_PATH: [playwrightLibraryPath, process.env.LD_LIBRARY_PATH]
+                    .filter(Boolean)
+                    .join(":"),
+                },
+              },
+            }),
             instances: [{ browser: "chromium" }],
             commands: {
               async inspectBuiltRoute(context) {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ import solid from "vite-plugin-solid";
 import { defineConfig } from "vitest/config";
 
 const playwrightLibraryPath = resolve(".cloudflare/playwright-deps/usr/lib/x86_64-linux-gnu");
+const cloudBuildReadyTimeout = 90_000;
 
 export default defineConfig({
   resolve: { tsconfigPaths: true },
@@ -31,7 +32,7 @@ export default defineConfig({
           // Cloudflare Workers Builds share CPU while the built fixture and
           // Chromium run together, so route hydration can exceed Vitest's
           // 15-second default without indicating a failed assertion.
-          testTimeout: 60_000,
+          testTimeout: 120_000,
           browser: {
             enabled: true,
             headless: true,
@@ -57,10 +58,12 @@ export default defineConfig({
                   name: "The best foundation for your next SolidJS project",
                 });
 
-                await heading.waitFor({ state: "visible" });
+                await heading.waitFor({ state: "visible", timeout: cloudBuildReadyTimeout });
 
                 const previewFrame = routeFrame.frameLocator('iframe[title="Home Preview"]');
-                await previewFrame.locator(".theme-container").waitFor({ state: "visible" });
+                await previewFrame
+                  .locator(".theme-container")
+                  .waitFor({ state: "visible", timeout: cloudBuildReadyTimeout });
 
                 return {
                   heading: await heading.textContent(),
@@ -77,8 +80,10 @@ export default defineConfig({
                 const routeFrame = testFrame.frameLocator('iframe[title="Built chart route"]');
                 const chart = routeFrame.locator('[data-slot="chart"]');
 
-                await chart.waitFor({ state: "visible" });
-                await chart.locator(".recharts-surface").waitFor({ state: "visible" });
+                await chart.waitFor({ state: "visible", timeout: cloudBuildReadyTimeout });
+                await chart
+                  .locator(".recharts-surface")
+                  .waitFor({ state: "visible", timeout: cloudBuildReadyTimeout });
 
                 return {
                   chartSlot: await chart.getAttribute("data-chart"),


### PR DESCRIPTION
Supports #254 by locking the repository-owned preview isolation and no-gap validation retention contract while the Cloudflare Workers Builds integration is proven on this branch.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Locks the Cloudflare preview and validation-retention contracts while provisioning browser dependencies for Cloudflare builds.
- Adds repository-local installation and verification of Chromium runtime libraries.
- Configures browser tests to use those libraries and allows additional hydration time.
- Adds contract tests for preview isolation and retained validation/release files.
- Ignores generated Cloudflare artifacts.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, though the existing JSONC parsing concern remains unresolved.

The preview contract currently passes because wrangler.jsonc is strict JSON, but adding valid JSONC comments or trailing commas would still make contributor validation fail before evaluating the intended contract.

**Files Needing Attention:** tests/unit/toolchain-contract.test.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/install-cloudflare-playwright-deps.sh | Adds local download, extraction, and verification of Chromium runtime libraries for Cloudflare builds. |
| tests/unit/toolchain-contract.test.ts | Adds contract coverage for preview isolation and retention of existing validation and release files. |
| vitest.config.ts | Supplies the locally provisioned library path to Playwright and increases the browser-test timeout. |
| .gitignore | Excludes generated Cloudflare build artifacts from version control. |

<sub>Reviews (5): Last reviewed commit: ["fix(validation): allow Cloudflare browse..."](https://github.com/carere/zaidan/commit/e387226bccd3ac4bd383fa72329bf1a2602954a2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48178720)</sub>

<!-- /greptile_comment -->