### PR TITLE
refactor: prepare Zaidan for Solid 2

### DIFF
--- a/docs/research/solid2-wayfinder.md
+++ b/docs/research/solid2-wayfinder.md
@@ -1,0 +1,12 @@
+# Solid 2 migration wayfinder
+
+The canonical decision map is [Solid 2 migration: decision map](https://github.com/carere/zaidan/issues/494).
+Its native child issues hold investigations and decisions; their blocking relationships identify the next available work.
+
+This effort establishes a decision-complete migration direction for `to-spec`,
+followed by `to-tickets` and implementation. Research findings and decision
+resolutions are linked from the map rather than duplicated here.
+
+The working branch is `refactor/solid-2`. The migration pull request remains
+draft while this work proceeds. This initial change only establishes the
+planning entry point; it does not add Solid 2 support.


### PR DESCRIPTION
Zaidan currently targets Solid 1. This draft tracks the migration of its registry and website to Solid 2 while preserving appearance and interaction behavior.

The current change adds only an entry point to [Solid 2 migration: decision map](https://github.com/carere/zaidan/issues/494). Wayfinder resolves the migration decisions before `to-spec`, `to-tickets`, and implementation. Solid 2 support is not implemented yet.

Required direction: replace Corvu with Kobalte 2 primitives, cmdk-solid with Kobalte Search, solid-sonner with Kobalte Toast, and @dnd-kit/solid with @solid-primitives/drag-drop@next; verify compatible chart, carousel, TanStack, and website toolchain sources. Necessary public API changes must be documented.

Solid 1 remains on main while Solid 2 is developed here. Once Solid 2 is released and dependencies are ready, preserve v1 on a legacy branch before merging this refactor into main.

Validation: documentation-only entry point; no runtime changes or runtime tests. Keep this PR draft throughout planning and migration.
